### PR TITLE
🐛 Fix bug where sharing a parameterless URL with `MutationType.URL_PARAMS_SPECIFIC` throws NPE

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
     <img alt="FixMyLinks" src="./.github/images//logo-wordmark-light.svg" height="96">
 </picture>
 
-### 🔗🛠️ Replace domain names and remove unwanted tracking data from links shared on Android
+**🔗🛠️ Replace domain names and remove unwanted tracking data from links shared on Android**
 
-<br>
+---
+
+<br >
 
 # How do I use FixMyLinks?
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 ---
 
-<br >
-
 # How do I use FixMyLinks?
 
 ## Replace domain names

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         minSdk = 29
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0"
+        versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
-    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.activity:activity-compose:1.8.0")
 
     implementation(platform("androidx.compose:compose-bom:2023.10.00"))
     implementation("androidx.compose.ui:ui")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
     implementation("androidx.activity:activity-compose:1.7.2")
 
-    implementation(platform("androidx.compose:compose-bom:2023.09.00"))
+    implementation(platform("androidx.compose:compose-bom:2023.10.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -66,12 +66,14 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
 
     implementation("com.google.android.material:material:1.9.0")
+
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
+
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
@@ -114,17 +114,17 @@ class MutateUriUseCase {
         }
 
         // Create a map of URL param key/value pairs that should be present in the mutated URL
-        val filteredUrlParams = paramPairs.toMap().filter { (key, _) ->
+        val requiredUrlParams = paramPairs.toMap().filter { (key, _) ->
             // filter out keys that should be removed
             !paramsToRemove.contains(key)
         }
 
         // If no params need to be present in the mutated URL (since all params in the URL exist in
         // `paramsToRemove`), return the URL without any params
-        if (filteredUrlParams.isEmpty()) return URI(removeAllUrlParams(uri.toString()))
+        if (requiredUrlParams.isEmpty()) return URI(removeAllUrlParams(uri.toString()))
 
         // Format the map of new params in the correct format required for URLs
-        val mutatedQueryString = filteredUrlParams.entries.joinToString("&") { (key, value) ->
+        val mutatedQueryString = requiredUrlParams.entries.joinToString("&") { (key, value) ->
             "$key=$value"
         }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
@@ -62,7 +62,7 @@ class MutateUriUseCase {
         paramsToRemove: List<String>,
         useWwwSubdomain: Boolean
     ): URI {
-        if (paramsToRemove.isEmpty()) return uri
+        if (uri.rawQuery == null || paramsToRemove.isEmpty()) return uri
 
         val queryString = uri.rawQuery
 

--- a/app/src/test/java/com/suvanl/fixmylinks/LinkMutationTests.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/LinkMutationTests.kt
@@ -81,4 +81,17 @@ class LinkMutationTests {
 
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun `attempt to remove URL parameters of a parameterless Spotify link`() {
+        val mutateUriUseCase = MutateUriUseCase()
+        val actual = mutateUriUseCase(
+            uri = URI("https://open.spotify.com/track/3PRljkcobGtC6Kc3ILLSmq"),
+            mutationType = MutationType.URL_PARAMS_SPECIFIC
+        )
+        // URI should not change
+        val expected = URI("https://open.spotify.com/track/3PRljkcobGtC6Kc3ILLSmq")
+
+        assertEquals(expected, actual)
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.1" apply false
+    id("com.android.application") version "8.1.2" apply false
     id("org.jetbrains.kotlin.android") version "1.8.10" apply false
     id("com.guardsquare.appsweep") version "latest.release" apply false
 }


### PR DESCRIPTION
If a link that was already parameterless is shared using the FixMyLinks "Share to..." share sheet option, a NullPointerException would be thrown as we would be trying to access `uri.rawQuery`, which would be `null` if the URL had no query string / params. This PR fixes and adds a test for this issue (90ee6d2bba108e398b4ca96a2f71df663c197321, 533aa5ee5c403bc5c0f1fbe75410f14a98c08121 respectively).

### Other notable changes
- Updated Compose BOM and AndroidX Activity dependencies (37e6de081bdef2fa0ab2da6b890d5a189bfa13a6, b15b2adef3b3b37b716a9bf60438c4e37deeadd8)
- Updated AGP (8.1.1 to 8.1.2) (075a08ee34a1629c9dc0c1645d8f3139a4fe9af6)
- Enabled predictive back gesture support (809bfbfa2e5108066238b0252011104ea1c83d63)
  - This Android feature is currently hidden behind a developer option on API level 34, but it will be supported due to the possibility of it being made stable in Android 15 (Vanilla Ice Cream)