### PR TITLE
♻️ Change order of "add new rule" flow

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.20" />
+    <option name="version" value="1.9.10" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.10" />
+    <option name="version" value="1.9.20" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.guardsquare.appsweep")
-    id("com.google.devtools.ksp") version "1.9.0-1.0.13"
+    id("com.google.devtools.ksp") version "1.9.10-1.0.13"
 }
 
 android {
@@ -42,7 +42,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.3"
     }
     packaging {
         resources {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.guardsquare.appsweep")
+    id("com.google.devtools.ksp") version "1.9.0-1.0.13"
 }
 
 android {
@@ -53,6 +54,7 @@ android {
 dependencies {
     val lifecycleVersion = "2.6.2"
     val navVersion = "2.7.4"
+    val roomVersion = "2.6.0"
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
@@ -60,6 +62,10 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion")
     implementation("androidx.navigation:navigation-compose:$navVersion")
     implementation("androidx.activity:activity-compose:1.8.0")
+
+    implementation("androidx.room:room-runtime:$roomVersion")
+    implementation("androidx.room:room-ktx:$roomVersion")
+    ksp("androidx.room:room-compiler:$roomVersion")
 
     implementation(platform("androidx.compose:compose-bom:2023.10.01"))
     implementation("androidx.compose.ui:ui")
@@ -73,12 +79,14 @@ dependencies {
 
 
     testImplementation("junit:junit:4.13.2")
+    testImplementation("androidx.room:room-testing:$roomVersion")
+
+    androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))
     androidTestImplementation("androidx.navigation:navigation-testing:$navVersion")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/AddNewRuleFlowTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/AddNewRuleFlowTest.kt
@@ -1,0 +1,37 @@
+package com.suvanl.fixmylinks
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Test suite for the "Add New Rule" user flow, in which users can create and save a new custom rule
+ */
+@RunWith(AndroidJUnit4::class)
+class AddNewRuleFlowTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    /**
+     * Verify that we end up on the SelectRuleTypeScreen upon clicking the FAB
+     */
+    @Test
+    fun clickFab_navigatesToSelectRuleType() {
+        composeTestRule
+            .onNodeWithTag("Add New Rule FAB")
+            .assertExists()
+            .assertIsDisplayed()
+            .performClick()
+
+        composeTestRule
+            .onNodeWithContentDescription("Select Rule Type Screen")
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioGroup.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioGroup.kt
@@ -1,0 +1,102 @@
+package com.suvanl.fixmylinks.ui.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+/**
+ * Stateless RadioGroup composable
+ */
+@Composable
+fun RadioGroup(
+    options: List<RadioOptionData>,
+    selectedOptionId: String,
+    onOptionClick: (currentOption: RadioOptionData) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Modifier.selectableGroup() is essential to ensure correct accessibility behavior
+    Column(Modifier.selectableGroup()) {
+        options.forEach { optionData ->
+            RadioOption(
+                data = optionData,
+                isSelected = optionData.id == selectedOptionId,
+                onClick = { onOptionClick(optionData) },
+                modifier = modifier.padding(horizontal = 8.dp)
+            )
+        }
+    }
+}
+
+/**
+ * Stateful RadioGroup composable
+ */
+@Composable
+fun RadioGroup(
+    options: List<RadioOptionData>,
+    selectedState: MutableState<RadioOptionData>,
+    modifier: Modifier = Modifier
+) {
+    val (selectedOption, onOptionSelected) = selectedState
+
+    // Modifier.selectableGroup() is essential to ensure correct accessibility behavior
+    Column(Modifier.selectableGroup()) {
+        options.forEach { optionData ->
+            RadioOption(
+                data = optionData,
+                isSelected = optionData == selectedOption,
+                onClick = {
+                    onOptionSelected(
+                        options.find { it == optionData } ?: options.first()
+                    )
+                },
+                modifier = modifier.padding(horizontal = 16.dp)
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 320
+)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun RadioGroupPreview() {
+    val radioOptions = listOf(
+        RadioOptionData(
+            id = "calls",
+            title = "Calls",
+            description = "Something pretty descriptive"
+        ),
+        RadioOptionData(
+            id = "missed",
+            title = "Missed",
+            description = "Interesting description"
+        ),
+        RadioOptionData(
+            id = "friends",
+            title = "Friends",
+            description = "Descriptions can definitely be longer than this!"
+        ),
+    )
+
+    PreviewContainer {
+        RadioGroup(
+            options = radioOptions,
+            selectedOptionId = "calls",
+            onOptionClick = { /* do nothing */ }
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioOption.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioOption.kt
@@ -1,0 +1,128 @@
+package com.suvanl.fixmylinks.ui.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+data class RadioOptionData(
+    val id: String,
+    val title: String?,
+    val description: String
+)
+
+@Composable
+fun RadioOption(
+    data: RadioOptionData,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val rowContentDescription = stringResource(
+        R.string.radio_option_content_description,
+        data.title ?: data.description
+    )
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = isSelected,
+                onClick = onClick,
+                role = Role.RadioButton
+            )
+            .semantics { contentDescription = rowContentDescription },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        RadioButton(
+            selected = isSelected,
+            onClick = null  // null recommended for accessibility with screen readers
+        )
+
+        Column(
+            modifier = modifier.padding(16.dp)
+        ) {
+            if (data.title != null) {
+                Text(
+                    text = data.title,
+                    style = MaterialTheme.typography.titleLarge
+                )
+            }
+
+            Text(
+                text = data.description,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 320
+)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun RadioOptionWithTitlePreview() {
+    val option = RadioOptionData(
+        id = "sample",
+        title = "Sample option",
+        description = "Sample description text - lorem ipsum sit dolor amet etc etc etc"
+    )
+
+    PreviewContainer {
+        RadioOption(
+            data = option,
+            isSelected = true,
+            onClick = { /* do nothing */ }
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 320
+)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun RadioOptionPreview() {
+    val option = RadioOptionData(
+        id = "sample",
+        title = null,
+        description = "Sample option"
+    )
+
+    PreviewContainer {
+        RadioOption(
+            data = option,
+            isSelected = true,
+            onClick = { /* do nothing */ }
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/button/AddNewRuleFab.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/button/AddNewRuleFab.kt
@@ -9,6 +9,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import com.suvanl.fixmylinks.R
 
 @Composable
@@ -19,7 +21,8 @@ fun AddNewRuleFab(
 ) {
     FloatingActionButton(
         onClick = { onClick() },
-        elevation = elevation
+        elevation = elevation,
+        modifier = modifier.semantics { testTag = "Add New Rule FAB" }
     ) {
         Icon(
             imageVector = Icons.Outlined.Add,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationRail.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationRail.kt
@@ -23,7 +23,8 @@ fun FmlNavigationRail(
         header = {
             AddNewRuleFab(
                 onClick = { onFabClick() },
-                elevation = FloatingActionButtonDefaults.bottomAppBarFabElevation()
+                elevation = FloatingActionButtonDefaults.bottomAppBarFabElevation(),
+                modifier = modifier
             )
         },
         containerColor = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationRail.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationRail.kt
@@ -27,12 +27,12 @@ fun FmlNavigationRail(
             )
         },
         containerColor = MaterialTheme.colorScheme.background,
-        modifier = Modifier.padding(8.dp)
+        modifier = modifier.padding(8.dp)
     ) {
         Column(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.fillMaxHeight()
+            modifier = modifier.fillMaxHeight()
         ) {
             navItemsColumn()
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/TopAppBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/TopAppBar.kt
@@ -13,6 +13,8 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
 
@@ -32,7 +34,8 @@ fun FmlTopAppBar(
             TopAppBar(
                 title = { TopAppBarTitle(text = title) },
                 navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
-                scrollBehavior = scrollBehavior
+                scrollBehavior = scrollBehavior,
+                modifier = modifier
             )
         }
 
@@ -40,15 +43,17 @@ fun FmlTopAppBar(
             MediumTopAppBar(
                 title = { TopAppBarTitle(text = title) },
                 navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
-                scrollBehavior = scrollBehavior
+                scrollBehavior = scrollBehavior,
+                modifier = modifier
             )
         }
 
         TopAppBarSize.LARGE -> {
             LargeTopAppBar(
-                title = { TopAppBarTitle(text = title) },
+                title = { TopAppBarTitle(text = title, fontSize = 32.sp) },
                 navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
-                scrollBehavior = scrollBehavior
+                scrollBehavior = scrollBehavior,
+                modifier = modifier
             )
         }
     }
@@ -57,11 +62,25 @@ fun FmlTopAppBar(
 @Composable
 private fun TopAppBarTitle(
     text: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    fontSize: TextUnit? = null
 ) {
+    val letterSpacing = TIGHT_LETTER_SPACING.times(16)
+
+    if (fontSize == null) {
+        Text(
+            text = text,
+            letterSpacing = letterSpacing,
+            modifier = modifier
+        )
+        return
+    }
+
     Text(
         text = text,
-        letterSpacing = (TIGHT_LETTER_SPACING.times(16))
+        letterSpacing = letterSpacing,
+        fontSize = fontSize,
+        modifier = modifier
     )
 }
 
@@ -70,7 +89,10 @@ private fun TopAppBarNavigationIcon(
     onNavigateUp: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    IconButton(onClick = { onNavigateUp() }) {
+    IconButton(
+        onClick = onNavigateUp,
+        modifier = modifier
+    ) {
         Icon(
             imageVector = Icons.Default.ArrowBack,
             contentDescription = stringResource(id = R.string.navigate_up)

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/TopAppBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/TopAppBar.kt
@@ -5,6 +5,8 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -14,29 +16,64 @@ import androidx.compose.ui.res.stringResource
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
 
+enum class TopAppBarSize { SMALL, MEDIUM, LARGE }
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FmlTopAppBar(
     title: String,
     onNavigateUp: () -> Unit,
+    size: TopAppBarSize,
     scrollBehavior: TopAppBarScrollBehavior,
     modifier: Modifier = Modifier
 ) {
-    TopAppBar(
-        title = {
-            Text(
-                text = title,
-                letterSpacing = (TIGHT_LETTER_SPACING.times(16))
+    when (size) {
+        TopAppBarSize.SMALL -> {
+            TopAppBar(
+                title = { TopAppBarTitle(text = title) },
+                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                scrollBehavior = scrollBehavior
             )
-        },
-        navigationIcon = {
-            IconButton(onClick = { onNavigateUp() }) {
-                Icon(
-                    imageVector = Icons.Default.ArrowBack,
-                    contentDescription = stringResource(id = R.string.navigate_up)
-                )
-            }
-        },
-        scrollBehavior = scrollBehavior
+        }
+
+        TopAppBarSize.MEDIUM -> {
+            MediumTopAppBar(
+                title = { TopAppBarTitle(text = title) },
+                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                scrollBehavior = scrollBehavior
+            )
+        }
+
+        TopAppBarSize.LARGE -> {
+            LargeTopAppBar(
+                title = { TopAppBarTitle(text = title) },
+                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                scrollBehavior = scrollBehavior
+            )
+        }
+    }
+}
+
+@Composable
+private fun TopAppBarTitle(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = text,
+        letterSpacing = (TIGHT_LETTER_SPACING.times(16))
     )
+}
+
+@Composable
+private fun TopAppBarNavigationIcon(
+    onNavigateUp: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    IconButton(onClick = { onNavigateUp() }) {
+        Icon(
+            imageVector = Icons.Default.ArrowBack,
+            contentDescription = stringResource(id = R.string.navigate_up)
+        )
+    }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -6,10 +6,12 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import com.suvanl.fixmylinks.ui.screens.AddRuleScreen
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreen
 import com.suvanl.fixmylinks.ui.screens.HomeScreen
 import com.suvanl.fixmylinks.ui.screens.RulesScreen
 import com.suvanl.fixmylinks.ui.screens.SavedScreen
+import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
 
 @Composable
 fun FmlNavHost(navController: NavHostController, modifier: Modifier = Modifier) {
@@ -30,8 +32,20 @@ fun FmlNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
             SavedScreen()
         }
 
-        composable(route = FmlScreen.AddRule.route) {
-            AddRuleScreen()
+        composable(route = FmlScreen.SelectRuleType.route) {
+            SelectRuleTypeScreen()
+        }
+
+        composable(
+            route = FmlScreen.AddRule.routeWithArgs,
+            arguments = FmlScreen.AddRule.args
+        ) { navBackStackEntry ->
+            val mutationTypeArg =
+                navBackStackEntry.arguments?.getString(FmlScreen.AddRule.mutationTypeArg)
+
+            val mutationType = MutationType.valueOf(mutationTypeArg ?: "FALLBACK")
+
+            AddRuleScreen(mutationType)
         }
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.LibraryBooks
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.suvanl.fixmylinks.R
 
 sealed class FmlScreen(
@@ -19,36 +22,63 @@ sealed class FmlScreen(
     val selectedIcon: ImageVector = Icons.Filled.Star,
     val unselectedIcon: ImageVector = Icons.Outlined.StarOutline
 ) {
-    object Home : FmlScreen(
+    private interface FmlScreenWithArgs {
+        /**
+         * A list of navigation arguments required by this screen
+         */
+        val args: List<NamedNavArgument>
+
+        /**
+         * The full route with arguments appended, such as
+         * `"myScreen/{firstArgument}"`
+         */
+        val routeWithArgs: String
+    }
+
+    data object Home : FmlScreen(
         route = "home",
         label = R.string.home,
         selectedIcon = Icons.Filled.Home,
         unselectedIcon = Icons.Outlined.Home
     )
 
-    object Rules : FmlScreen(
+    data object Rules : FmlScreen(
         route = "rules",
         label = R.string.rules,
         selectedIcon = Icons.Filled.LibraryBooks,
         unselectedIcon = Icons.Outlined.LibraryBooks
     )
 
-    object Saved : FmlScreen(
+    data object Saved : FmlScreen(
         route = "saved",
         label = R.string.saved,
         selectedIcon = Icons.Filled.Bookmarks,
         unselectedIcon = Icons.Outlined.Bookmarks
     )
 
-    object AddRule : FmlScreen(
+    data object SelectRuleType : FmlScreen(
+        route = "select_rule_type",
+        label = R.string.select_rule_type
+    )
+
+    data object AddRule : FmlScreen(
         route = "add_rule",
         label = R.string.add_new_rule
-    )
+    ), FmlScreenWithArgs {
+        const val mutationTypeArg = "mutation_type"
+
+        override val args: List<NamedNavArgument> = listOf(
+            navArgument(mutationTypeArg) { type = NavType.StringType },
+        )
+
+        override val routeWithArgs = "$route/{${mutationTypeArg}}"
+    }
 }
 
-val allFmlScreens = listOf(
+val allFmlScreens = setOf(
     FmlScreen.Home,
     FmlScreen.Rules,
     FmlScreen.Saved,
+    FmlScreen.SelectRuleType,
     FmlScreen.AddRule
 )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -46,6 +46,7 @@ import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.components.button.AddNewRuleFab
 import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationRail
 import com.suvanl.fixmylinks.ui.components.nav.FmlTopAppBar
+import com.suvanl.fixmylinks.ui.components.nav.TopAppBarSize
 import com.suvanl.fixmylinks.ui.navigation.FmlNavHost
 import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.navigation.allFmlScreens
@@ -73,7 +74,7 @@ fun FixMyLinksAppPortrait(
     showTopAppBar: Boolean = false,
 ) {
     FixMyLinksTheme {
-        val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+        val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
 
         Scaffold(
             topBar = {
@@ -81,6 +82,7 @@ fun FixMyLinksAppPortrait(
                     FmlTopAppBar(
                         title = topAppBarTitle,
                         onNavigateUp = { onNavigateUp() },
+                        size = TopAppBarSize.LARGE,
                         scrollBehavior = scrollBehavior
                     )
                 }
@@ -241,6 +243,7 @@ fun FixMyLinksAppLandscape(
                         FmlTopAppBar(
                             title = topAppBarTitle,
                             onNavigateUp = { onNavigateUp() },
+                            size = TopAppBarSize.SMALL,
                             scrollBehavior = scrollBehavior
                         )
                     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -263,7 +263,7 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
     val displayFabOn = listOf(FmlScreen.Home, FmlScreen.Rules)
 
     // The screens on which the Navigation Bar should be hidden
-    val hideNavBarOn = listOf(FmlScreen.AddRule)
+    val hideNavBarOn = listOf(FmlScreen.SelectRuleType, FmlScreen.AddRule)
 
     @Composable
     fun PortraitLayout() {
@@ -282,7 +282,7 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
             },
             onFabClick = {
                 navController.navigateSingleTop(
-                    route = FmlScreen.AddRule.route,
+                    route = FmlScreen.SelectRuleType.route,
                     popUpToStartDestination = false
                 )
             },
@@ -308,7 +308,7 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
             },
             onFabClick = {
                 navController.navigateSingleTop(
-                    route = FmlScreen.AddRule.route,
+                    route = FmlScreen.SelectRuleType.route,
                     popUpToStartDestination = false
                 )
             },

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -1,4 +1,4 @@
-package com.suvanl.fixmylinks.ui.screens
+package com.suvanl.fixmylinks.ui.screens.newruleflow
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,9 +12,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.domain.mutation.MutationType
 
 @Composable
-fun AddRuleScreen(modifier: Modifier = Modifier) {
+fun AddRuleScreen(
+    mutationType: MutationType,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier
             .verticalScroll(rememberScrollState())
@@ -23,7 +27,7 @@ fun AddRuleScreen(modifier: Modifier = Modifier) {
         Spacer(modifier = Modifier.height(16.dp))
 
         Text(
-            text = "Add a new rule!",
+            text = "Add a new ${mutationType.name} rule",
             modifier = modifier.padding(horizontal = 16.dp)
         )
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
@@ -40,7 +42,9 @@ fun SelectRuleTypeScreen(modifier: Modifier = Modifier) {
     val selectedOption = remember { mutableStateOf(radioOptions[0]) }
 
     Column(
-        modifier = modifier.padding(top = 16.dp)
+        modifier = modifier
+            .padding(top = 16.dp)
+            .semantics { contentDescription = "Select Rule Type Screen" }
     ) {
         RuleTypeRadioGroup(
             options = radioOptions,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
@@ -1,0 +1,30 @@
+package com.suvanl.fixmylinks.ui.screens.newruleflow
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SelectRuleTypeScreen(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .semantics { contentDescription = "Select Rule Type Screen" }
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Select rule type...",
+            modifier = modifier.padding(horizontal = 16.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
@@ -1,30 +1,71 @@
 package com.suvanl.fixmylinks.ui.screens.newruleflow
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.ui.components.RadioGroup
+import com.suvanl.fixmylinks.ui.components.RadioOptionData
+import com.suvanl.fixmylinks.ui.util.StringResourceUtil
 
 @Composable
 fun SelectRuleTypeScreen(modifier: Modifier = Modifier) {
-    Column(
-        modifier = modifier
-            .verticalScroll(rememberScrollState())
-            .semantics { contentDescription = "Select Rule Type Screen" }
-    ) {
-        Spacer(modifier = Modifier.height(16.dp))
+    val selectableMutationTypes = setOf(
+        MutationType.DOMAIN_NAME,
+        MutationType.URL_PARAMS_ALL,
+        MutationType.URL_PARAMS_SPECIFIC,
+        MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL
+    )
 
-        Text(
-            text = "Select rule type...",
-            modifier = modifier.padding(horizontal = 16.dp)
+    val radioOptions = selectableMutationTypes.map {
+        RadioOptionData(
+            id = it.name,
+            title = stringResource(
+                id = StringResourceUtil.humanizedMutationTypeNames.getOrDefault(
+                    key = it,
+                    defaultValue = StringResourceUtil.StringResource(R.string.empty)
+                ).id
+            ),
+            description = it.name.lowercase()
         )
     }
+
+    val selectedOption = remember { mutableStateOf(radioOptions[0]) }
+
+    Column(
+        modifier = modifier.padding(top = 16.dp)
+    ) {
+        RuleTypeRadioGroup(
+            options = radioOptions,
+            selectedState = selectedOption,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun RuleTypeRadioGroup(
+    options: List<RadioOptionData>,
+    selectedState: MutableState<RadioOptionData>,
+    modifier: Modifier = Modifier
+) {
+    val (selectedOption, onOptionSelected) = selectedState
+
+    RadioGroup(
+        options = options,
+        selectedOptionId = selectedOption.id,
+        onOptionClick = { currentOption ->
+            onOptionSelected(
+                options.find { it == currentOption } ?: options.first()
+            )
+        },
+        modifier = modifier
+    )
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Type.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Type.kt
@@ -22,6 +22,8 @@ private fun defaultCustomFont(
     )
 }
 
+val TIGHT_LETTER_SPACING = (-0.035F).sp
+
 private val defaultTypography = Typography()
 val Typography = Typography(
     // Display
@@ -84,7 +86,7 @@ val Typography = Typography(
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
+        letterSpacing = TIGHT_LETTER_SPACING
     ),
     bodyMedium = defaultTypography.bodyMedium.copy(
         fontFamily = defaultCustomFont()
@@ -94,4 +96,3 @@ val Typography = Typography(
     )
 )
 
-val TIGHT_LETTER_SPACING = (-0.035F).sp

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/PreviewContainer.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/PreviewContainer.kt
@@ -1,0 +1,23 @@
+package com.suvanl.fixmylinks.ui.util
+
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.suvanl.fixmylinks.ui.theme.FixMyLinksTheme
+
+/**
+ * A simple container that displays the given [content] within a [Surface], which itself is within
+ * a [FixMyLinksTheme] composable. This should be used in composable previews to ensure an accurate
+ * (in terms of how it'll look at runtime) representation of the design is displayed in the preview.
+ */
+@Composable
+fun PreviewContainer(
+    modifier: Modifier = Modifier,
+    content: @Composable (Modifier) -> Unit
+) {
+    FixMyLinksTheme {
+        Surface {
+            content(modifier)
+        }
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/StringResourceUtil.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/StringResourceUtil.kt
@@ -1,0 +1,22 @@
+package com.suvanl.fixmylinks.ui.util
+
+import androidx.annotation.StringRes
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+
+
+object StringResourceUtil {
+    // Required to guarantee type safety in maps (such as humanizedMutationTypeName) because
+    // otherwise the type of the value will simply be inferred as a standard `Int`, rather than a
+    // string resource ID.
+    data class StringResource(@StringRes val id: Int)
+
+    val humanizedMutationTypeNames = mapOf(
+        MutationType.DOMAIN_NAME to StringResource(R.string.mt_domain_name),
+        MutationType.URL_PARAMS_ALL to StringResource(R.string.mt_url_params_all),
+        MutationType.URL_PARAMS_SPECIFIC to StringResource(R.string.mt_url_params_specific),
+        MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL to StringResource(
+            R.string.mt_domain_name_and_url_params_all
+        )
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="add_new_rule">Add new rule</string>
     <string name="new_rule">New rule</string>
     <string name="navigate_up">Navigate up</string>
+    <string name="select_rule_type">Select rule type</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,13 @@
     <string name="new_rule">New rule</string>
     <string name="navigate_up">Navigate up</string>
     <string name="select_rule_type">Select rule type</string>
+
+    <string name="radio_option_content_description">%1$s option</string>
+
+    <!-- mt = mutation type -->
+    <string name="mt_domain_name">Change domain name</string>
+    <string name="mt_url_params_all">Remove all URL parameters</string>
+    <string name="mt_url_params_specific">Remove specific URL parameters</string>
+    <string name="mt_domain_name_and_url_params_all">Change domain name and remove all URL parameters</string>
+    <string name="empty" />
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.1.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
     id("com.guardsquare.appsweep") version "latest.release" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.1.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.10" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
     id("com.guardsquare.appsweep") version "latest.release" apply false
 }


### PR DESCRIPTION
Previously, tapping the FAB on the HomeScreen or RulesScreen would navigate directly to AddRuleScreen.

The new behaviour is that tapping the FAB first navigates to the new SelectRuleTypeScreen, where the user can select the rule's `MutationType` before providing `MutationType`-specific information on the next screen(s), such as AddRuleScreen (not implemented yet). AddRuleScreen now requires a `mutation_type` navigation argument, the value of which will be selected by the user on SelectRuleTypeScreen. This new flow is more logical in relation to the design of the Room/SQLite database that will store custom rules locally.

### Other changes
- **Kotlin version and Compose compiler version** (de9c7ebd0881541dab4672e528ffeb5a791415dd, b14b83630525d5e315136d830051e4b98760df2e)
The project's Kotlin version has been updated to 1.9.10, which is the version supported by the latest version of the Compose compiler (1.5.3), which we have upgraded to.

- **Add Room dependencies** (19bfff827ccd985f78dab769b37d85ad1211311e)
in preparation for using Room for local persistent storage