### PR TITLE
♻️ Refactor adaptive layout logic and support per-destination actions in top app bar

### DIFF
--- a/app/src/androidTest/java/com/suvanl/fixmylinks/NavigationTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/NavigationTest.kt
@@ -1,5 +1,6 @@
 package com.suvanl.fixmylinks
 
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -29,7 +30,10 @@ class NavigationTest {
             // Assign a ComposeNavigator to the navController so it can navigate through composables
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
-            FmlNavHost(navController = navController)
+            FmlNavHost(
+                navController = navController,
+                windowWidthSize = WindowWidthSizeClass.Compact
+            )
         }
     }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioOption.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioOption.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -28,7 +30,24 @@ data class RadioOptionData(
     val id: String,
     val title: String?,
     val description: String
-)
+) {
+    companion object {
+        /**
+         * [Saver] that converts a [RadioOptionData] object into a Saveable, to ensure that it can
+         * be stored in a Bundle.
+         */
+        val saver: Saver<RadioOptionData, *> = listSaver(
+            save = { listOf(it.id, it.title ?: "", it.description) },
+            restore = {
+                RadioOptionData(
+                    id = it[0],
+                    title = it[1],
+                    description = it[2]
+                )
+            }
+        )
+    }
+}
 
 @Composable
 fun RadioOption(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/AppBarActionRow.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/AppBarActionRow.kt
@@ -22,13 +22,16 @@ private class TopAppBarViewModel : ViewModel() {
 }
 
 @Composable
-fun ProvideAppBarActions(actions: @Composable RowScope.() -> Unit) {
+fun ProvideAppBarActions(
+    shouldShowActions: Boolean = true,
+    actions: @Composable RowScope.() -> Unit
+) {
     val viewModelStoreOwner = LocalViewModelStoreOwner.current
     if (viewModelStoreOwner == null || viewModelStoreOwner !is NavBackStackEntry) return
 
     val actionViewModel = viewModel(initializer = { TopAppBarViewModel() })
     SideEffect {
-        actionViewModel.actionState = actions
+        actionViewModel.actionState = if (shouldShowActions) actions else null
     }
 }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/AppBarActionRow.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/AppBarActionRow.kt
@@ -1,0 +1,43 @@
+package com.suvanl.fixmylinks.ui.components.appbar
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.referentialEqualityPolicy
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.compose.LocalOwnersProvider
+
+private class TopAppBarViewModel : ViewModel() {
+    var actionState by mutableStateOf<(@Composable RowScope.() -> Unit)?>(
+        value = null,
+        policy = referentialEqualityPolicy()
+    )
+}
+
+@Composable
+fun ProvideAppBarActions(actions: @Composable RowScope.() -> Unit) {
+    val viewModelStoreOwner = LocalViewModelStoreOwner.current
+    if (viewModelStoreOwner == null || viewModelStoreOwner !is NavBackStackEntry) return
+
+    val actionViewModel = viewModel(initializer = { TopAppBarViewModel() })
+    SideEffect {
+        actionViewModel.actionState = actions
+    }
+}
+
+@Composable
+fun RowScope.AppBarActionRow(navBackStackEntry: NavBackStackEntry?) {
+    val stateHolder = rememberSaveableStateHolder()
+
+    navBackStackEntry?.LocalOwnersProvider(stateHolder) {
+        val actionViewModel = viewModel(initializer = { TopAppBarViewModel() })
+        actionViewModel.actionState?.let { it() }
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/TopAppBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/TopAppBar.kt
@@ -11,11 +11,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.TextUnit
+import androidx.navigation.FloatingWindow
+import androidx.navigation.NavBackStackEntry
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNot
 
 enum class TopAppBarSize { SMALL, MEDIUM, LARGE }
 
@@ -25,14 +31,25 @@ fun FmlTopAppBar(
     title: String,
     size: TopAppBarSize,
     scrollBehavior: TopAppBarScrollBehavior,
+    currentBackStackEntryFlow: Flow<NavBackStackEntry>,
     onNavigateUp: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val currentContentBackStackEntry by produceState(
+        initialValue = null as NavBackStackEntry?,
+        producer = {
+            currentBackStackEntryFlow
+                .filterNot { it.destination is FloatingWindow }
+                .collect { value = it }
+        }
+    )
+
     when (size) {
         TopAppBarSize.SMALL -> {
             TopAppBar(
                 title = { TopAppBarTitle(text = title) },
                 navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                actions = { AppBarActionRow(navBackStackEntry = currentContentBackStackEntry) },
                 scrollBehavior = scrollBehavior,
                 modifier = modifier
             )
@@ -42,6 +59,7 @@ fun FmlTopAppBar(
             MediumTopAppBar(
                 title = { TopAppBarTitle(text = title) },
                 navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                actions = { AppBarActionRow(navBackStackEntry = currentContentBackStackEntry) },
                 scrollBehavior = scrollBehavior,
                 modifier = modifier
             )
@@ -51,6 +69,7 @@ fun FmlTopAppBar(
             LargeTopAppBar(
                 title = { TopAppBarTitle(text = title) },
                 navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                actions = { AppBarActionRow(navBackStackEntry = currentContentBackStackEntry) },
                 scrollBehavior = scrollBehavior,
                 modifier = modifier
             )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/TopAppBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/TopAppBar.kt
@@ -1,4 +1,4 @@
-package com.suvanl.fixmylinks.ui.components.nav
+package com.suvanl.fixmylinks.ui.components.appbar
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -23,9 +23,9 @@ enum class TopAppBarSize { SMALL, MEDIUM, LARGE }
 @Composable
 fun FmlTopAppBar(
     title: String,
-    onNavigateUp: () -> Unit,
     size: TopAppBarSize,
     scrollBehavior: TopAppBarScrollBehavior,
+    onNavigateUp: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     when (size) {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationBar.kt
@@ -1,0 +1,63 @@
+package com.suvanl.fixmylinks.ui.components.nav
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hierarchy
+import com.suvanl.fixmylinks.ui.navigation.FmlScreen
+import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
+
+@Composable
+fun FmlNavigationBar(
+    navItems: List<FmlScreen>,
+    currentDestination: NavDestination?,
+    onNavItemClick: (FmlScreen) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    NavigationBar(modifier = modifier) {
+        navItems.forEach { screen ->
+            val isSelected =
+                currentDestination?.hierarchy?.any { it.route == screen.route } == true
+
+            NavigationBarItem(
+                selected = isSelected,
+                onClick = { onNavItemClick(screen) },
+                icon = {
+                    Icon(
+                        imageVector = if (isSelected) {
+                            screen.selectedIcon
+                        } else {
+                            screen.unselectedIcon
+                        },
+                        contentDescription = null
+                    )
+                },
+                label = {
+                    Column {
+                        Text(
+                            text = stringResource(id = screen.label),
+                            letterSpacing = TIGHT_LETTER_SPACING,
+                            fontWeight = if (isSelected) {
+                                FontWeight.Bold
+                            } else {
+                                FontWeight.Normal
+                            },
+                            fontSize = 13.sp,
+                            modifier = Modifier.padding(top = 64.dp)
+                        )
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationRail.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationRail.kt
@@ -2,23 +2,34 @@ package com.suvanl.fixmylinks.ui.components.nav
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hierarchy
 import com.suvanl.fixmylinks.ui.components.button.AddNewRuleFab
+import com.suvanl.fixmylinks.ui.navigation.FmlScreen
+import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
 
 @Composable
 fun FmlNavigationRail(
     onFabClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    itemsColumnScope: @Composable ColumnScope.() -> Unit
+    navItems: List<FmlScreen>,
+    onNavItemClick: (FmlScreen) -> Unit,
+    currentDestination: NavDestination?,
+    modifier: Modifier = Modifier
 ) {
     NavigationRail(
         header = {
@@ -34,8 +45,44 @@ fun FmlNavigationRail(
         Column(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = modifier.fillMaxHeight(),
-            content = itemsColumnScope
-        )
+            modifier = modifier.fillMaxHeight()
+        ) {
+            navItems.forEachIndexed { index, screen ->
+                val isSelected =
+                    currentDestination?.hierarchy?.any { it.route == screen.route } == true
+
+                NavigationRailItem(
+                    selected = isSelected,
+                    onClick = { onNavItemClick(screen) },
+                    icon = {
+                        Icon(
+                            imageVector = if (isSelected) {
+                                screen.selectedIcon
+                            } else {
+                                screen.unselectedIcon
+                            },
+                            contentDescription = null
+                        )
+                    },
+                    label = {
+                        Column {
+                            Text(
+                                text = stringResource(id = screen.label),
+                                letterSpacing = TIGHT_LETTER_SPACING,
+                                fontWeight = if (isSelected) {
+                                    FontWeight.Bold
+                                } else {
+                                    FontWeight.Normal
+                                },
+                            )
+                        }
+                    }
+                )
+
+                if (index != navItems.lastIndex) {
+                    Spacer(modifier = Modifier.padding(8.dp))
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
-import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -30,7 +29,7 @@ import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
 @Composable
 fun FmlNavHost(
     navController: NavHostController,
-    windowSize: WindowSizeClass,
+    windowWidthSize: WindowWidthSizeClass,
     modifier: Modifier = Modifier
 ) {
     NavHost(
@@ -65,7 +64,7 @@ fun FmlNavHost(
         composable(route = FmlScreen.SelectRuleType.route) {
             // Show "Next" button as top app bar action on Medium and Expanded layouts
             ProvideAppBarActions(
-                shouldShowActions = windowSize.widthSizeClass != WindowWidthSizeClass.Compact
+                shouldShowActions = windowWidthSize != WindowWidthSizeClass.Compact
             ) {
                 Button(onClick = { /*TODO*/ }) {
                     Text(text = stringResource(id = R.string.next))
@@ -75,7 +74,7 @@ fun FmlNavHost(
             }
 
             SelectRuleTypeScreen(
-                showNextButton = windowSize.widthSizeClass == WindowWidthSizeClass.Compact
+                showNextButton = windowWidthSize == WindowWidthSizeClass.Compact
             )
         }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -1,14 +1,22 @@
 package com.suvanl.fixmylinks.ui.navigation
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.ui.components.appbar.ProvideAppBarActions
 import com.suvanl.fixmylinks.ui.navigation.transition.NavigationEnterTransitionMode
 import com.suvanl.fixmylinks.ui.navigation.transition.NavigationExitTransitionMode
 import com.suvanl.fixmylinks.ui.navigation.transition.enterNavigationTransition
@@ -55,6 +63,17 @@ fun FmlNavHost(
         }
 
         composable(route = FmlScreen.SelectRuleType.route) {
+            // Show "Next" button as top app bar action on Medium and Expanded layouts
+            ProvideAppBarActions(
+                shouldShowActions = windowSize.widthSizeClass != WindowWidthSizeClass.Compact
+            ) {
+                Button(onClick = { /*TODO*/ }) {
+                    Text(text = stringResource(id = R.string.next))
+                }
+
+                Spacer(modifier = Modifier.width(16.dp))
+            }
+
             SelectRuleTypeScreen(
                 showNextButton = windowSize.widthSizeClass == WindowWidthSizeClass.Compact
             )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -1,5 +1,7 @@
 package com.suvanl.fixmylinks.ui.navigation
 
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -18,7 +20,11 @@ import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
 
 @Composable
-fun FmlNavHost(navController: NavHostController, modifier: Modifier = Modifier) {
+fun FmlNavHost(
+    navController: NavHostController,
+    windowSize: WindowSizeClass,
+    modifier: Modifier = Modifier
+) {
     NavHost(
         navController = navController,
         startDestination = FmlScreen.Home.route,
@@ -49,7 +55,9 @@ fun FmlNavHost(navController: NavHostController, modifier: Modifier = Modifier) 
         }
 
         composable(route = FmlScreen.SelectRuleType.route) {
-            SelectRuleTypeScreen()
+            SelectRuleTypeScreen(
+                showNextButton = windowSize.widthSizeClass == WindowWidthSizeClass.Compact
+            )
         }
 
         composable(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.slideInHorizontally
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -16,13 +15,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
@@ -32,14 +27,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.components.button.AddNewRuleFab
+import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationBar
 import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationRail
 import com.suvanl.fixmylinks.ui.components.nav.FmlTopAppBar
 import com.suvanl.fixmylinks.ui.components.nav.TopAppBarSize
@@ -48,7 +40,6 @@ import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.navigation.allFmlScreens
 import com.suvanl.fixmylinks.ui.navigation.navigateSingleTop
 import com.suvanl.fixmylinks.ui.theme.FixMyLinksTheme
-import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
 
 private val topLevelNavItems = listOf(
     FmlScreen.Home,
@@ -109,42 +100,13 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
             },
             bottomBar = {
                 if (shouldShowNavBar) {
-                    NavigationBar {
-                        topLevelNavItems.forEach { screen ->
-                            val isSelected =
-                                currentDestination?.hierarchy?.any { it.route == screen.route } == true
-
-                            NavigationBarItem(
-                                selected = isSelected,
-                                onClick = { navController.navigateSingleTop(screen.route) },
-                                icon = {
-                                    Icon(
-                                        imageVector = if (isSelected) {
-                                            screen.selectedIcon
-                                        } else {
-                                            screen.unselectedIcon
-                                        },
-                                        contentDescription = null
-                                    )
-                                },
-                                label = {
-                                    Column {
-                                        Text(
-                                            text = stringResource(id = screen.label),
-                                            letterSpacing = TIGHT_LETTER_SPACING,
-                                            fontWeight = if (isSelected) {
-                                                FontWeight.Bold
-                                            } else {
-                                                FontWeight.Normal
-                                            },
-                                            fontSize = 13.sp,
-                                            modifier = Modifier.padding(top = 64.dp)
-                                        )
-                                    }
-                                }
-                            )
-                        }
-                    }
+                    FmlNavigationBar(
+                        navItems = topLevelNavItems,
+                        onNavItemClick = { screen ->
+                            navController.navigateSingleTop(screen.route)
+                        },
+                        currentDestination = currentDestination
+                    )
                 }
             },
             floatingActionButton = {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -172,7 +172,7 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
 
                     FmlNavHost(
                         navController = navController,
-                        windowSize = windowSize
+                        windowWidthSize = windowSize.widthSizeClass
                     )
                 }
             }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -170,7 +170,10 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
                         )
                     }
 
-                    FmlNavHost(navController = navController)
+                    FmlNavHost(
+                        navController = navController,
+                        windowSize = windowSize
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -7,7 +7,6 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -21,7 +20,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -192,50 +190,21 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
                         )
                     ) {
                         FmlNavigationRail(
+                            navItems = topLevelNavItems,
+                            currentDestination = currentDestination,
                             onFabClick = {
                                 navController.navigateSingleTop(
                                     route = FmlScreen.SelectRuleType.route,
+                                    // we want to return to the screen the FAB was clicked on (i.e.
+                                    // the previous destination) when popping the back stack rather
+                                    // than popping all the way up to the startDestination.
                                     popUpToStartDestination = false
                                 )
+                            },
+                            onNavItemClick = { screen ->
+                                navController.navigateSingleTop(screen.route)
                             }
-                        ) {
-                            topLevelNavItems.forEachIndexed { index, screen ->
-                                val isSelected =
-                                    currentDestination?.hierarchy?.any { it.route == screen.route } == true
-
-                                NavigationRailItem(
-                                    selected = isSelected,
-                                    onClick = { navController.navigateSingleTop(screen.route) },
-                                    icon = {
-                                        Icon(
-                                            imageVector = if (isSelected) {
-                                                screen.selectedIcon
-                                            } else {
-                                                screen.unselectedIcon
-                                            },
-                                            contentDescription = null
-                                        )
-                                    },
-                                    label = {
-                                        Column {
-                                            Text(
-                                                text = stringResource(id = screen.label),
-                                                letterSpacing = TIGHT_LETTER_SPACING,
-                                                fontWeight = if (isSelected) {
-                                                    FontWeight.Bold
-                                                } else {
-                                                    FontWeight.Normal
-                                                },
-                                            )
-                                        }
-                                    }
-                                )
-
-                                if (index != topLevelNavItems.lastIndex) {
-                                    Spacer(modifier = Modifier.padding(8.dp))
-                                }
-                            }
-                        }
+                        )
                     }
 
                     FmlNavHost(navController = navController)

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -33,8 +33,8 @@ import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.components.button.AddNewRuleFab
 import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationBar
 import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationRail
-import com.suvanl.fixmylinks.ui.components.nav.FmlTopAppBar
-import com.suvanl.fixmylinks.ui.components.nav.TopAppBarSize
+import com.suvanl.fixmylinks.ui.components.appbar.FmlTopAppBar
+import com.suvanl.fixmylinks.ui.components.appbar.TopAppBarSize
 import com.suvanl.fixmylinks.ui.navigation.FmlNavHost
 import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.navigation.allFmlScreens

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -94,7 +94,8 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
                         title = stringResource(id = currentScreen?.label ?: R.string.app_name),
                         onNavigateUp = { navController.navigateUp() },
                         size = topAppBarSize,
-                        scrollBehavior = topAppBarScrollBehavior
+                        scrollBehavior = topAppBarScrollBehavior,
+                        currentBackStackEntryFlow = navController.currentBackStackEntryFlow
                     )
                 }
             },

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -52,7 +52,9 @@ fun SelectRuleTypeScreen(modifier: Modifier = Modifier) {
         )
     }
 
-    val selectedOption = remember { mutableStateOf(radioOptions[0]) }
+    val selectedOption = rememberSaveable(stateSaver = RadioOptionData.saver) {
+        mutableStateOf(radioOptions[0])
+    }
 
     Column(
         modifier = modifier

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
@@ -26,7 +26,10 @@ import com.suvanl.fixmylinks.ui.components.RadioOptionData
 import com.suvanl.fixmylinks.ui.util.StringResourceUtil
 
 @Composable
-fun SelectRuleTypeScreen(modifier: Modifier = Modifier) {
+fun SelectRuleTypeScreen(
+    showNextButton: Boolean,
+    modifier: Modifier = Modifier
+) {
     val selectableMutationTypes = setOf(
         MutationType.DOMAIN_NAME,
         MutationType.URL_PARAMS_ALL,
@@ -70,19 +73,24 @@ fun SelectRuleTypeScreen(modifier: Modifier = Modifier) {
             modifier = Modifier.padding(bottom = 4.dp)
         )
 
-        Row(
-            modifier = modifier
-                .fillMaxWidth()
-                .weight(1F, fill = false)
-        ) {
-            Button(
-                onClick = { /*TODO*/ },
+        // The row containing the "Next" button is conditionally shown as it won't be required
+        // in cases where this button is provided inside the Top App Bar instead, i.e.,
+        // medium and expanded layouts.
+        if (showNextButton) {
+            Row(
                 modifier = modifier
                     .fillMaxWidth()
-                    .padding(bottom = 32.dp)
-                    .padding(horizontal = 8.dp)
+                    .weight(1F, fill = false)
             ) {
-                Text(text = stringResource(id = R.string.next))
+                Button(
+                    onClick = { /*TODO*/ },
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 32.dp)
+                        .padding(horizontal = 8.dp)
+                ) {
+                    Text(text = stringResource(id = R.string.next))
+                }
             }
         }
     }


### PR DESCRIPTION
## ♻️ Refactor adaptive layout logic
The adaptive layout logic in the app-level composable (`FixMyLinksApp`) has been refactored to use a `Scaffold` regardless of the window size class, with components specific to certain window size classes being rendered conditionally.

This has been done to ensure consistency across different window/display sizes while still ensuring that layouts can adapt to different screen sizes. It also fixes a state bug where using `rememberSaveable` to store state that survives activity/process recreation would result in states specific to a window size class, since the layout for each window width size class had its own `FmlNavHost`, meaning technically a different screen would be shown depending on the window size. With this new approach, a single, common `FmlNavHost` composable exists throughout the app, thus fixing the state bug.

## ✨Support per-destination actions in the top app bar
Refactoring the adaptive layout logic also ensures a single top app bar is truly shared across layouts and allows us to incorporate this into the adaptive layout model. It is now possible to have per-destination actions in the top app bar, which can restore their state when required. This currently is being used to display the "Next" button when on `SelectRuleTypeScreen` in the top app bar on `WindowWidthSizeClass.Medium` and `WindowWidthSizeClass.Expanded` layouts, rather than in `SelectRuleTypeScreen`.