### PR TITLE
✨ Create and use MutationType-specific forms in AddRuleScreen

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.10" />
+    <option name="version" value="1.9.20" />
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.guardsquare.appsweep")
-    id("com.google.devtools.ksp") version "1.9.10-1.0.13"
+    id("com.google.devtools.ksp") version "1.9.20-1.0.14"
 }
 
 android {
@@ -42,7 +42,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.3"
+        kotlinCompilerExtensionVersion = "1.5.4"
     }
     packaging {
         resources {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/animation/TransitionDefaults.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/animation/TransitionDefaults.kt
@@ -1,0 +1,15 @@
+package com.suvanl.fixmylinks.ui.animation
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+
+object TransitionDefaults {
+    val supportingTextEnterTransition = fadeIn() + expandVertically(
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessLow
+        )
+    )
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioGroup.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioGroup.kt
@@ -2,17 +2,18 @@ package com.suvanl.fixmylinks.ui.components
 
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 
 private val radioOptionHorizontalPadding = 8.dp
-private val radioOptionDefaultSpacerHeight = 40.dp
 
 @Composable
 private fun BaseRadioGroup(
@@ -36,7 +37,8 @@ fun RadioGroup(
     options: List<RadioOptionData>,
     selectedOptionId: String,
     onOptionClick: (currentOption: RadioOptionData) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    customSpacerHeight: Dp? = null,
 ) {
     BaseRadioGroup(
         options = options,
@@ -45,9 +47,15 @@ fun RadioGroup(
         RadioOption(
             data = optionData,
             isSelected = optionData.id == selectedOptionId,
-            spacerHeight = if (optionIndex == options.lastIndex) 0.dp else radioOptionDefaultSpacerHeight,
+            spacerHeight = if (optionIndex == options.lastIndex) {
+                0.dp
+            } else {
+                customSpacerHeight ?: RadioOptionDefaults.spacerHeight
+            },
             onClick = { onOptionClick(optionData) },
-            modifier = Modifier.padding(horizontal = radioOptionHorizontalPadding)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = radioOptionHorizontalPadding)
         )
     }
 }
@@ -59,7 +67,8 @@ fun RadioGroup(
 fun RadioGroup(
     options: List<RadioOptionData>,
     selectedState: MutableState<RadioOptionData>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    customSpacerHeight: Dp? = null,
 ) {
     val (selectedOption, onOptionSelected) = selectedState
 
@@ -70,13 +79,19 @@ fun RadioGroup(
         RadioOption(
             data = optionData,
             isSelected = optionData == selectedOption,
-            spacerHeight = if (optionIndex == options.lastIndex) 0.dp else radioOptionDefaultSpacerHeight,
+            spacerHeight = if (optionIndex == options.lastIndex) {
+                0.dp
+            } else {
+                customSpacerHeight ?: RadioOptionDefaults.spacerHeight
+            },
             onClick = {
                 onOptionSelected(
                     options.find { it == optionData } ?: options.first()
                 )
             },
-            modifier = Modifier.padding(horizontal = radioOptionHorizontalPadding)
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = radioOptionHorizontalPadding)
         )
     }
 }
@@ -115,7 +130,8 @@ private fun RadioGroupPreview() {
         RadioGroup(
             options = radioOptions,
             selectedOptionId = "calls",
-            onOptionClick = { /* do nothing */ }
+            onOptionClick = { /* do nothing */ },
+            customSpacerHeight = 32.dp,
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioGroup.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioGroup.kt
@@ -47,11 +47,11 @@ fun RadioGroup(
         RadioOption(
             data = optionData,
             isSelected = optionData.id == selectedOptionId,
-            spacerHeight = if (optionIndex == options.lastIndex) {
-                0.dp
-            } else {
-                customSpacerHeight ?: RadioOptionDefaults.spacerHeight
-            },
+            spacerHeight = calculateSpacerHeight(
+                currentIndex = optionIndex,
+                lastIndex = options.lastIndex,
+                customHeight = customSpacerHeight
+            ),
             onClick = { onOptionClick(optionData) },
             modifier = Modifier
                 .fillMaxWidth()
@@ -79,11 +79,11 @@ fun RadioGroup(
         RadioOption(
             data = optionData,
             isSelected = optionData == selectedOption,
-            spacerHeight = if (optionIndex == options.lastIndex) {
-                0.dp
-            } else {
-                customSpacerHeight ?: RadioOptionDefaults.spacerHeight
-            },
+            spacerHeight = calculateSpacerHeight(
+                optionIndex,
+                options.lastIndex,
+                customSpacerHeight
+            ),
             onClick = {
                 onOptionSelected(
                     options.find { it == optionData } ?: options.first()
@@ -93,6 +93,14 @@ fun RadioGroup(
                 .fillMaxWidth()
                 .padding(horizontal = radioOptionHorizontalPadding)
         )
+    }
+}
+
+private fun calculateSpacerHeight(currentIndex: Int, lastIndex: Int, customHeight: Dp?): Dp {
+    return if (currentIndex == lastIndex) {
+        0.dp
+    } else {
+        customHeight ?: RadioOptionDefaults.spacerHeight
     }
 }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioOption.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/RadioOption.kt
@@ -4,7 +4,6 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
@@ -49,13 +48,17 @@ data class RadioOptionData(
     }
 }
 
+object RadioOptionDefaults {
+    val spacerHeight = 40.dp
+}
+
 @Composable
 fun RadioOption(
     data: RadioOptionData,
     isSelected: Boolean,
-    spacerHeight: Dp,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    spacerHeight: Dp = RadioOptionDefaults.spacerHeight,
 ) {
     val rowContentDescription = stringResource(
         R.string.radio_option_content_description,
@@ -65,7 +68,6 @@ fun RadioOption(
     Column {
         Row(
             modifier = modifier
-                .fillMaxWidth()
                 .selectable(
                     selected = isSelected,
                     onClick = onClick,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/TopAppBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/TopAppBar.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.navigation.FloatingWindow
 import androidx.navigation.NavBackStackEntry
 import com.suvanl.fixmylinks.R
-import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
+import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNot
 
@@ -83,7 +83,7 @@ private fun TopAppBarTitle(
     modifier: Modifier = Modifier,
     fontSize: TextUnit? = null
 ) {
-    val letterSpacing = TIGHT_LETTER_SPACING.times(16)
+    val letterSpacing = LetterSpacingDefaults.ExtraTight
 
     if (fontSize == null) {
         Text(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/menu/HintsDropdownItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/menu/HintsDropdownItem.kt
@@ -11,7 +11,6 @@ import com.suvanl.fixmylinks.R
 @Composable
 fun HintsDropdownItem(
     isChecked: Boolean,
-    onClick: () -> Unit,
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -19,11 +18,11 @@ fun HintsDropdownItem(
         text = {
             Text(text = stringResource(id = R.string.show_hints))
         },
-        onClick = onClick,
+        onClick = { onCheckedChange(!isChecked) },
         trailingIcon = {
             Checkbox(
                 checked = isChecked,
-                onCheckedChange = onCheckedChange
+                onCheckedChange = null  // null recommended for accessibility with screen readers
             )
         },
         modifier = modifier

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/menu/HintsDropdownItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/menu/HintsDropdownItem.kt
@@ -1,0 +1,31 @@
+package com.suvanl.fixmylinks.ui.components.appbar.menu
+
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.suvanl.fixmylinks.R
+
+@Composable
+fun HintsDropdownItem(
+    isChecked: Boolean,
+    onClick: () -> Unit,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    DropdownMenuItem(
+        text = {
+            Text(text = stringResource(id = R.string.show_hints))
+        },
+        onClick = onClick,
+        trailingIcon = {
+            Checkbox(
+                checked = isChecked,
+                onCheckedChange = onCheckedChange
+            )
+        },
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/menu/HintsDropdownItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/menu/HintsDropdownItem.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.theme.TextStyleDefaults
 
 @Composable
 fun HintsDropdownItem(
@@ -16,7 +17,10 @@ fun HintsDropdownItem(
 ) {
     DropdownMenuItem(
         text = {
-            Text(text = stringResource(id = R.string.show_hints))
+            Text(
+                text = stringResource(id = R.string.show_hints),
+                style = TextStyleDefaults.dropdownItemStyle
+            )
         },
         onClick = { onCheckedChange(!isChecked) },
         trailingIcon = {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/menu/OverflowMenu.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/menu/OverflowMenu.kt
@@ -1,0 +1,62 @@
+package com.suvanl.fixmylinks.ui.components.appbar.menu
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.suvanl.fixmylinks.R
+
+/**
+ * Stateful [DropdownMenu] containing `DropdownItem`s, for use as an app bar's overflow menu
+ */
+@Composable
+fun OverflowMenu(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    var showMenu by remember { mutableStateOf(false) }
+
+    OverflowMenu(
+        showMenu = showMenu,
+        onOverflowIconClick = { showMenu = !showMenu },
+        onDismissRequest = { showMenu = false },
+        modifier = modifier
+    ) {
+        content()
+    }
+}
+
+/**
+ * Stateless [DropdownMenu] containing `DropdownItem`s, for use as an app bar's overflow menu
+ */
+@Composable
+fun OverflowMenu(
+    showMenu: Boolean,
+    onOverflowIconClick: () -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    IconButton(onClick = onOverflowIconClick) {
+        Icon(
+            imageVector = Icons.Outlined.MoreVert,
+            contentDescription = stringResource(id = R.string.content_description_more_options)
+        )
+    }
+
+    DropdownMenu(
+        expanded = showMenu,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier
+    ) {
+        content()
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
@@ -21,10 +21,10 @@ import com.suvanl.fixmylinks.ui.util.PreviewContainer
 @Composable
 fun AllUrlParamsRuleForm(
     showHints: Boolean,
-    interFieldSpacing: Dp,
     onRuleNameChange: (String) -> Unit,
     onDomainNameChange: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    interFieldSpacing: Dp = FormDefaults.InterFieldSpacing,
 ) {
     var ruleNameText by rememberSaveable { mutableStateOf("") }
     var domainNameText by rememberSaveable { mutableStateOf("") }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
@@ -50,6 +50,7 @@ fun AllUrlParamsRuleForm(
                 domainNameText = it
                 onDomainNameChange(it)
             },
+            isLastFieldInForm = true,
             modifier = Modifier.fillMaxWidth()
         )
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
@@ -6,10 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -21,22 +17,18 @@ import com.suvanl.fixmylinks.ui.util.PreviewContainer
 @Composable
 fun AllUrlParamsRuleForm(
     showHints: Boolean,
+    ruleNameText: String,
+    domainNameText: String,
     onRuleNameChange: (String) -> Unit,
     onDomainNameChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     interFieldSpacing: Dp = FormDefaults.InterFieldSpacing,
 ) {
-    var ruleNameText by rememberSaveable { mutableStateOf("") }
-    var domainNameText by rememberSaveable { mutableStateOf("") }
-
     Column(modifier = modifier) {
         // "Rule name"
         RuleNameField(
             text = ruleNameText,
-            onValueChange = {
-                ruleNameText = it
-                onRuleNameChange(it)
-            },
+            onValueChange = onRuleNameChange,
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -46,10 +38,7 @@ fun AllUrlParamsRuleForm(
         DomainNameField(
             value = domainNameText,
             showHints = showHints,
-            onValueChange = {
-                domainNameText = it
-                onDomainNameChange(it)
-            },
+            onValueChange = onDomainNameChange,
             isLastFieldInForm = true,
             modifier = Modifier.fillMaxWidth()
         )
@@ -69,6 +58,8 @@ private fun AllUrlParamsRuleFormPreview() {
             interFieldSpacing = 16.dp,
             onRuleNameChange = {},
             onDomainNameChange = {},
+            ruleNameText = "",
+            domainNameText = "",
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
@@ -1,0 +1,73 @@
+package com.suvanl.fixmylinks.ui.components.form
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.ui.components.form.common.DomainNameField
+import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+@Composable
+fun AllUrlParamsRuleForm(
+    showHints: Boolean,
+    interFieldSpacing: Dp,
+    onRuleNameChange: (String) -> Unit,
+    onDomainNameChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var ruleNameText by rememberSaveable { mutableStateOf("") }
+    var domainNameText by rememberSaveable { mutableStateOf("") }
+
+    Column(modifier = modifier) {
+        // "Rule name"
+        RuleNameField(
+            text = ruleNameText,
+            onValueChange = {
+                ruleNameText = it
+                onRuleNameChange(it)
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(interFieldSpacing))
+
+        // "Domain name"
+        DomainNameField(
+            value = domainNameText,
+            showHints = showHints,
+            onValueChange = {
+                domainNameText = it
+                onDomainNameChange(it)
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Preview
+@Preview(
+    name = "Dark",
+    uiMode = UI_MODE_NIGHT_YES
+)
+@Composable
+private fun AllUrlParamsRuleFormPreview() {
+    PreviewContainer {
+        AllUrlParamsRuleForm(
+            showHints = true,
+            interFieldSpacing = 16.dp,
+            onRuleNameChange = {},
+            onDomainNameChange = {},
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -1,0 +1,107 @@
+package com.suvanl.fixmylinks.ui.components.form
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Language
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.Dp
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
+
+@Composable
+fun DomainNameRuleForm(
+    interFieldSpacing: Dp,
+    onRuleNameChange: (String) -> Unit,
+    onInitialDomainNameChange: (String) -> Unit,
+    onTargetDomainNameChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var ruleNameText by rememberSaveable { mutableStateOf("") }
+    var initialDomainNameText by rememberSaveable { mutableStateOf("") }
+    var targetDomainNameText by rememberSaveable { mutableStateOf("") }
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        // "Rule name"
+        RuleNameField(
+            text = ruleNameText,
+            onValueChange = {
+                ruleNameText = it
+                onRuleNameChange(it)
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(interFieldSpacing))
+
+        // "Initial domain name"
+        OutlinedTextField(
+            value = initialDomainNameText,
+            onValueChange = {
+                initialDomainNameText = it
+                onInitialDomainNameChange(it)
+            },
+            singleLine = true,
+            label = {
+                Text(text = stringResource(id = R.string.initial_domain_name))
+            },
+            supportingText = {
+                Text(text = stringResource(id = R.string.initial_domain_supporting_text))
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Outlined.Language,
+                    contentDescription = null
+                )
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Uri,
+                imeAction = ImeAction.Next
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(interFieldSpacing))
+
+        // "Target domain name"
+        OutlinedTextField(
+            value = targetDomainNameText,
+            onValueChange = {
+                targetDomainNameText = it
+                onTargetDomainNameChange(it)
+            },
+            singleLine = true,
+            label = {
+                Text(text = stringResource(id = R.string.target_domain_name))
+            },
+            supportingText = {
+                Text(text = stringResource(id = R.string.target_domain_supporting_text))
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Outlined.Language,
+                    contentDescription = null
+                )
+            },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Uri,
+                imeAction = ImeAction.Done
+            ),
+            modifier = modifier
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -28,11 +28,11 @@ import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
 @Composable
 fun DomainNameRuleForm(
     showHints: Boolean,
-    interFieldSpacing: Dp,
     onRuleNameChange: (String) -> Unit,
     onInitialDomainNameChange: (String) -> Unit,
     onTargetDomainNameChange: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    interFieldSpacing: Dp = FormDefaults.InterFieldSpacing,
 ) {
     var ruleNameText by rememberSaveable { mutableStateOf("") }
     var initialDomainNameText by rememberSaveable { mutableStateOf("") }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -12,10 +12,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -28,24 +24,20 @@ import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
 @Composable
 fun DomainNameRuleForm(
     showHints: Boolean,
+    ruleNameText: String,
+    initialDomainNameText: String,
+    targetDomainNameText: String,
     onRuleNameChange: (String) -> Unit,
     onInitialDomainNameChange: (String) -> Unit,
     onTargetDomainNameChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     interFieldSpacing: Dp = FormDefaults.InterFieldSpacing,
 ) {
-    var ruleNameText by rememberSaveable { mutableStateOf("") }
-    var initialDomainNameText by rememberSaveable { mutableStateOf("") }
-    var targetDomainNameText by rememberSaveable { mutableStateOf("") }
-
     Column(modifier = modifier) {
         // "Rule name"
         RuleNameField(
             text = ruleNameText,
-            onValueChange = {
-                ruleNameText = it
-                onRuleNameChange(it)
-            },
+            onValueChange = onRuleNameChange,
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -54,10 +46,7 @@ fun DomainNameRuleForm(
         // "Initial domain name"
         OutlinedTextField(
             value = initialDomainNameText,
-            onValueChange = {
-                initialDomainNameText = it
-                onInitialDomainNameChange(it)
-            },
+            onValueChange = onInitialDomainNameChange,
             singleLine = true,
             label = {
                 Text(text = stringResource(id = R.string.initial_domain_name))
@@ -88,10 +77,7 @@ fun DomainNameRuleForm(
         // "Target domain name"
         OutlinedTextField(
             value = targetDomainNameText,
-            onValueChange = {
-                targetDomainNameText = it
-                onTargetDomainNameChange(it)
-            },
+            onValueChange = onTargetDomainNameChange,
             singleLine = true,
             label = {
                 Text(text = stringResource(id = R.string.target_domain_name))

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -38,7 +38,7 @@ fun DomainNameRuleForm(
     var initialDomainNameText by rememberSaveable { mutableStateOf("") }
     var targetDomainNameText by rememberSaveable { mutableStateOf("") }
 
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(modifier = modifier) {
         // "Rule name"
         RuleNameField(
             text = ruleNameText,
@@ -114,7 +114,7 @@ fun DomainNameRuleForm(
                 keyboardType = KeyboardType.Uri,
                 imeAction = ImeAction.Done
             ),
-            modifier = modifier
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -1,5 +1,6 @@
 package com.suvanl.fixmylinks.ui.components.form
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,10 +22,12 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.Dp
 import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.animation.TransitionDefaults
 import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
 
 @Composable
 fun DomainNameRuleForm(
+    showHints: Boolean,
     interFieldSpacing: Dp,
     onRuleNameChange: (String) -> Unit,
     onInitialDomainNameChange: (String) -> Unit,
@@ -60,7 +63,12 @@ fun DomainNameRuleForm(
                 Text(text = stringResource(id = R.string.initial_domain_name))
             },
             supportingText = {
-                Text(text = stringResource(id = R.string.initial_domain_supporting_text))
+                AnimatedVisibility(
+                    visible = showHints,
+                    enter = TransitionDefaults.supportingTextEnterTransition
+                ) {
+                    Text(text = stringResource(id = R.string.initial_domain_supporting_text))
+                }
             },
             leadingIcon = {
                 Icon(
@@ -89,7 +97,12 @@ fun DomainNameRuleForm(
                 Text(text = stringResource(id = R.string.target_domain_name))
             },
             supportingText = {
-                Text(text = stringResource(id = R.string.target_domain_supporting_text))
+                AnimatedVisibility(
+                    visible = showHints,
+                    enter = TransitionDefaults.supportingTextEnterTransition
+                ) {
+                    Text(text = stringResource(id = R.string.target_domain_supporting_text))
+                }
             },
             leadingIcon = {
                 Icon(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/FormDefaults.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/FormDefaults.kt
@@ -1,0 +1,10 @@
+package com.suvanl.fixmylinks.ui.components.form
+
+import androidx.compose.ui.unit.dp
+
+object FormDefaults {
+    /**
+     * The default amount of vertical space between form fields
+     */
+    val InterFieldSpacing = 12.dp
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
@@ -1,6 +1,9 @@
 package com.suvanl.fixmylinks.ui.components.form
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -21,11 +24,6 @@ import androidx.compose.material3.InputChipDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -44,23 +42,19 @@ fun SpecificUrlParamsRuleForm(
     showHints: Boolean,
     interFieldSpacing: Dp,
     addedParamNames: List<String>,
+    ruleNameText: String,
+    domainNameText: String,
     onRuleNameChange: (String) -> Unit,
     onDomainNameChange: (String) -> Unit,
     onClickAddParam: () -> Unit,
     onClickDismissParam: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var ruleNameText by rememberSaveable { mutableStateOf("") }
-    var domainNameText by rememberSaveable { mutableStateOf("") }
-
     Column(modifier = modifier) {
         // "Rule name"
         RuleNameField(
             text = ruleNameText,
-            onValueChange = {
-                ruleNameText = it
-                onRuleNameChange(it)
-            },
+            onValueChange = onRuleNameChange,
             modifier = Modifier.fillMaxWidth()
         )
 
@@ -70,10 +64,7 @@ fun SpecificUrlParamsRuleForm(
         DomainNameField(
             value = domainNameText,
             showHints = showHints,
-            onValueChange = {
-                domainNameText = it
-                onDomainNameChange(it)
-            },
+            onValueChange = onDomainNameChange,
             isLastFieldInForm = true,
             modifier = Modifier.fillMaxWidth()
         )
@@ -117,16 +108,18 @@ private fun ParamsChipGroup(
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier = modifier
+            .fillMaxWidth()
+            .animateContentSize(
+                animationSpec = spring(
+                    dampingRatio = Spring.DampingRatioLowBouncy,
+                    stiffness = Spring.StiffnessLow
+                )
+            )
     ) {
         paramNames.forEachIndexed { index, name ->
-            var selected by remember { mutableStateOf(false) }
-
             InputChip(
-                selected = selected,
-                onClick = {
-                    selected = !selected
-                    onChipDismiss(index)
-                },
+                selected = false,
+                onClick = { onChipDismiss(index) },
                 label = { Text(text = name) },
                 trailingIcon = {
                     Icon(
@@ -152,6 +145,8 @@ private fun SpecificUrlParamsRuleFormPreview() {
             interFieldSpacing = 16.dp,
             showHints = true,
             addedParamNames = listOf("param1", "ok", "cool", "t", "calm", "g", "igshid"),
+            domainNameText = "",
+            ruleNameText = "",
             onRuleNameChange = {},
             onDomainNameChange = {},
             onClickAddParam = {},

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
@@ -40,7 +40,6 @@ import com.suvanl.fixmylinks.ui.util.PreviewContainer
 @Composable
 fun SpecificUrlParamsRuleForm(
     showHints: Boolean,
-    interFieldSpacing: Dp,
     addedParamNames: List<String>,
     ruleNameText: String,
     domainNameText: String,
@@ -48,7 +47,8 @@ fun SpecificUrlParamsRuleForm(
     onDomainNameChange: (String) -> Unit,
     onClickAddParam: () -> Unit,
     onClickDismissParam: (Int) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    interFieldSpacing: Dp = FormDefaults.InterFieldSpacing,
 ) {
     Column(modifier = modifier) {
         // "Rule name"

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
@@ -1,0 +1,160 @@
+package com.suvanl.fixmylinks.ui.components.form
+
+import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AddCircleOutline
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.InputChip
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.components.form.common.DomainNameField
+import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+@Composable
+fun SpecificUrlParamsRuleForm(
+    showHints: Boolean,
+    interFieldSpacing: Dp,
+    addedParamNames: List<String>,
+    onRuleNameChange: (String) -> Unit,
+    onDomainNameChange: (String) -> Unit,
+    onClickAddParam: () -> Unit,
+    onClickDismissParam: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var ruleNameText by rememberSaveable { mutableStateOf("") }
+    var domainNameText by rememberSaveable { mutableStateOf("") }
+
+    Column(modifier = modifier) {
+        // "Rule name"
+        RuleNameField(
+            text = ruleNameText,
+            onValueChange = {
+                ruleNameText = it
+                onRuleNameChange(it)
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(interFieldSpacing))
+
+        // "Domain name"
+        DomainNameField(
+            value = domainNameText,
+            showHints = showHints,
+            onValueChange = {
+                domainNameText = it
+                onDomainNameChange(it)
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(interFieldSpacing))
+
+        // "Parameters to remove"
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = "Add names of parameters to remove",
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.secondary
+            )
+
+            FilledTonalIconButton(
+                onClick = onClickAddParam,
+                modifier = Modifier.semantics { contentDescription = "Add" }
+            ) {
+                Icon(imageVector = Icons.Outlined.AddCircleOutline, contentDescription = "Add")
+            }
+        }
+
+        ParamsChipGroup(
+            paramNames = addedParamNames,
+            onChipDismiss = onClickDismissParam
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+@Composable
+private fun ParamsChipGroup(
+    paramNames: List<String>,
+    onChipDismiss: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier
+    ) {
+        paramNames.forEachIndexed { index, name ->
+            var selected by remember { mutableStateOf(false) }
+
+            InputChip(
+                selected = selected,
+                onClick = {
+                    selected = !selected
+                    onChipDismiss(index)
+                },
+                label = { Text(text = name) },
+                trailingIcon = {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = stringResource(id = R.string.delete),
+                        modifier = Modifier.size(InputChipDefaults.AvatarSize)
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Preview
+@Preview(
+    name = "Dark",
+    uiMode = UI_MODE_NIGHT_YES
+)
+@Composable
+private fun SpecificUrlParamsRuleFormPreview() {
+    PreviewContainer {
+        SpecificUrlParamsRuleForm(
+            interFieldSpacing = 16.dp,
+            showHints = true,
+            addedParamNames = listOf("param1", "ok", "cool", "t", "calm", "g", "igshid"),
+            onRuleNameChange = {},
+            onDomainNameChange = {},
+            onClickAddParam = {},
+            onClickDismissParam = {},
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
@@ -74,6 +74,7 @@ fun SpecificUrlParamsRuleForm(
                 domainNameText = it
                 onDomainNameChange(it)
             },
+            isLastFieldInForm = true,
             modifier = Modifier.fillMaxWidth()
         )
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
@@ -19,6 +19,7 @@ import com.suvanl.fixmylinks.ui.animation.TransitionDefaults
 fun DomainNameField(
     value: String,
     showHints: Boolean,
+    isLastFieldInForm: Boolean,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -45,7 +46,7 @@ fun DomainNameField(
         },
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Uri,
-            imeAction = ImeAction.Next
+            imeAction = if (!isLastFieldInForm) ImeAction.Next else ImeAction.Done
         ),
         modifier = modifier
     )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
@@ -1,0 +1,52 @@
+package com.suvanl.fixmylinks.ui.components.form.common
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Language
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.animation.TransitionDefaults
+
+@Composable
+fun DomainNameField(
+    value: String,
+    showHints: Boolean,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        label = {
+            Text(text = stringResource(id = R.string.domain_name))
+        },
+        supportingText = {
+            AnimatedVisibility(
+                visible = showHints,
+                enter = TransitionDefaults.supportingTextEnterTransition
+            ) {
+                Text(text = stringResource(id = R.string.domain_name_supporting_text))
+            }
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Outlined.Language,
+                contentDescription = null
+            )
+        },
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Uri,
+            imeAction = ImeAction.Next
+        ),
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/ParameterNameField.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/ParameterNameField.kt
@@ -1,0 +1,50 @@
+package com.suvanl.fixmylinks.ui.components.form.common
+
+import android.content.res.Configuration
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun ParameterNameField(
+    text: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    OutlinedTextField(
+        value = text,
+        onValueChange = onValueChange,
+        singleLine = true,
+        label = {
+            Text(text = stringResource(id = R.string.url_parameter_name))
+        },
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+        keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+        modifier = modifier
+    )
+}
+
+@Preview(widthDp = 320)
+@Preview(
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun ParameterNameFieldPreview() {
+    PreviewContainer {
+        ParameterNameField(text = "", onValueChange = {})
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/RuleNameField.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/RuleNameField.kt
@@ -1,5 +1,6 @@
 package com.suvanl.fixmylinks.ui.components.form.common
 
+import android.content.res.Configuration
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Description
@@ -10,7 +11,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
 
 @Composable
 fun RuleNameField(
@@ -37,4 +40,16 @@ fun RuleNameField(
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
         modifier = modifier
     )
+}
+
+@Preview(widthDp = 320)
+@Preview(
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun RuleNameFieldPreview() {
+    PreviewContainer {
+        RuleNameField(text = "", onValueChange = {})
+    }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/RuleNameField.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/RuleNameField.kt
@@ -1,0 +1,40 @@
+package com.suvanl.fixmylinks.ui.components.form.common
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import com.suvanl.fixmylinks.R
+
+@Composable
+fun RuleNameField(
+    text: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = text,
+        onValueChange = onValueChange,
+        singleLine = true,
+        label = {
+            Text(text = stringResource(id = R.string.rule_name))
+        },
+        supportingText = {
+            Text(stringResource(id = R.string.rule_name_is_optional_supporting_text))
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Outlined.Description,
+                contentDescription = null
+            )
+        },
+        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+        modifier = modifier
+    )
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/SwitchList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/SwitchList.kt
@@ -1,0 +1,82 @@
+package com.suvanl.fixmylinks.ui.components.list
+
+import android.content.res.Configuration
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.NotificationAdd
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+@Composable
+fun SwitchList(
+    items: List<SwitchListItemState>,
+    modifier: Modifier = Modifier,
+    elevation: CardElevation = CardDefaults.cardElevation(),
+) {
+    Card(
+        elevation = elevation,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        shape = RoundedCornerShape(24.dp),
+        modifier = modifier
+    ) {
+        items.forEachIndexed { index, item -> 
+            SwitchListItem(listItemState = item)
+
+            if (index != items.lastIndex) {
+                Divider(
+                    color = MaterialTheme.colorScheme.background,
+                    thickness = 2.dp
+                )
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 320)
+@Preview(
+    name = "Dark",
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+fun SwitchListPreview() {
+    PreviewContainer {
+        val items = listOf(
+            SwitchListItemState(
+                headlineText = "Hello, world",
+                supportingText = "Some supporting text",
+                leadingIcon = Icons.Outlined.AutoAwesome,
+                isSwitchChecked = true,
+                onSwitchCheckedChange = {}
+            ),
+            SwitchListItemState(
+                headlineText = "Lorem ipsum sit dolor",
+                supportingText = "Some more supporting text!",
+                leadingIcon = Icons.Outlined.NotificationAdd,
+                isSwitchChecked = true,
+                onSwitchCheckedChange = {}
+            ),
+            SwitchListItemState(
+                headlineText = "Yet another item",
+                supportingText = "With, you guessed it, more supporting text!",
+                leadingIcon = Icons.Outlined.Share,
+                isSwitchChecked = false,
+                onSwitchCheckedChange = {}
+            )
+        )
+
+        SwitchList(items = items)
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/SwitchListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/SwitchListItem.kt
@@ -1,0 +1,118 @@
+package com.suvanl.fixmylinks.ui.components.list
+
+import android.content.res.Configuration
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+data class SwitchListItemState(
+    val headlineText: String,
+    val supportingText: String,
+    val leadingIcon: ImageVector,
+    val isSwitchChecked: Boolean,
+    val onSwitchCheckedChange: (Boolean) -> Unit,
+    val isSwitchEnabled: Boolean = true
+)
+
+@Composable
+fun SwitchListItem(
+    listItemState: SwitchListItemState,
+    modifier: Modifier = Modifier
+) {
+    ListItem(
+        headlineContent = {
+            Text(
+                text = listItemState.headlineText,
+                style = MaterialTheme.typography.titleLarge,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        },
+        supportingContent = {
+            Text(
+                text = listItemState.supportingText,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        },
+        leadingContent = {
+            Icon(
+                imageVector = listItemState.leadingIcon,
+                contentDescription = null  // decorative
+            )
+        },
+        trailingContent = {
+            Switch(
+                checked = listItemState.isSwitchChecked,
+                onCheckedChange = listItemState.onSwitchCheckedChange,
+                enabled = listItemState.isSwitchEnabled
+            )
+        },
+        colors = ListItemDefaults.colors(
+            containerColor = Color.Transparent
+        ),
+        modifier = modifier
+    )
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 320
+)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+fun SwitchListItemOnPreview() {
+    PreviewContainer {
+        SwitchListItem(
+            listItemState = SwitchListItemState(
+                headlineText = "Headline",
+                supportingText = "Supporting text",
+                leadingIcon = Icons.Outlined.AutoAwesome,
+                isSwitchChecked = true,
+                onSwitchCheckedChange = {}
+            )
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 320
+)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+fun SwitchListItemOffPreview() {
+    PreviewContainer {
+        SwitchListItem(
+            listItemState = SwitchListItemState(
+                headlineText = "Headline",
+                supportingText = "Supporting text",
+                leadingIcon = Icons.Outlined.AutoAwesome,
+                isSwitchChecked = false,
+                onSwitchCheckedChange = {}
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationBar.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import com.suvanl.fixmylinks.ui.navigation.FmlScreen
-import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
+import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 
 @Composable
 fun FmlNavigationBar(
@@ -46,7 +46,7 @@ fun FmlNavigationBar(
                     Column {
                         Text(
                             text = stringResource(id = screen.label),
-                            letterSpacing = TIGHT_LETTER_SPACING,
+                            letterSpacing = LetterSpacingDefaults.Tight,
                             fontWeight = if (isSelected) {
                                 FontWeight.Bold
                             } else {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationRail.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationRail.kt
@@ -21,7 +21,7 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import com.suvanl.fixmylinks.ui.components.button.AddNewRuleFab
 import com.suvanl.fixmylinks.ui.navigation.FmlScreen
-import com.suvanl.fixmylinks.ui.theme.TIGHT_LETTER_SPACING
+import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 
 @Composable
 fun FmlNavigationRail(
@@ -68,7 +68,7 @@ fun FmlNavigationRail(
                         Column {
                             Text(
                                 text = stringResource(id = screen.label),
-                                letterSpacing = TIGHT_LETTER_SPACING,
+                                letterSpacing = LetterSpacingDefaults.Tight,
                                 fontWeight = if (isSelected) {
                                     FontWeight.Bold
                                 } else {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -6,7 +6,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -116,6 +119,7 @@ fun FmlNavHost(
             composable(route = FmlScreen.AddRule.route) { navBackStackEntry ->
                 val viewModel = navBackStackEntry.sharedViewModel<AddRuleViewModel>(navController)
                 val isCompactLayout = windowWidthSize == WindowWidthSizeClass.Compact
+                var hintsOptionCheckedState by remember { mutableStateOf(true) }
 
                 fun popCurrentNavGraph() {
                     navController.popBackStack(
@@ -135,15 +139,15 @@ fun FmlNavHost(
 
                     OverflowMenu {
                         HintsDropdownItem(
-                            isChecked = true,
-                            onClick = { /*TODO*/ },
-                            onCheckedChange = {}
+                            isChecked = hintsOptionCheckedState,
+                            onCheckedChange = { hintsOptionCheckedState = it }
                         )
                     }
                 }
 
                 AddRuleScreen(
                     mutationType = viewModel.mutationType.collectAsStateWithLifecycle().value,
+                    showFormFieldHints = hintsOptionCheckedState,
                     showSaveButton = isCompactLayout,
                     onSaveClick = { popCurrentNavGraph() }
                 )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -37,7 +37,7 @@ import com.suvanl.fixmylinks.ui.screens.RulesScreen
 import com.suvanl.fixmylinks.ui.screens.SavedScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
-import com.suvanl.fixmylinks.viewmodel.SelectRuleTypeViewModel
+import com.suvanl.fixmylinks.viewmodel.newruleflow.SelectRuleTypeViewModel
 
 @Composable
 fun FmlNavHost(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -115,7 +115,8 @@ fun FmlNavHost(
 
                 AddRuleScreen(
                     mutationType = viewModel.mutationType.collectAsStateWithLifecycle().value,
-                    onDoneClick = {
+                    showSaveButton = windowWidthSize == WindowWidthSizeClass.Compact,
+                    onSaveClick = {
                         navController.popBackStack(
                             route = NestedNavGraphParent.NewRuleFlow.route,
                             inclusive = true

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -22,7 +22,9 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.ui.components.appbar.menu.OverflowMenu
 import com.suvanl.fixmylinks.ui.components.appbar.ProvideAppBarActions
+import com.suvanl.fixmylinks.ui.components.appbar.menu.HintsDropdownItem
 import com.suvanl.fixmylinks.ui.navigation.transition.NavigationEnterTransitionMode
 import com.suvanl.fixmylinks.ui.navigation.transition.NavigationExitTransitionMode
 import com.suvanl.fixmylinks.ui.navigation.transition.enterNavigationTransition
@@ -75,10 +77,11 @@ fun FmlNavHost(
         ) {
             composable(route = FmlScreen.SelectRuleType.route) { navBackStackEntry ->
                 val viewModel = navBackStackEntry.sharedViewModel<AddRuleViewModel>(navController)
+                val isCompactLayout = windowWidthSize == WindowWidthSizeClass.Compact
 
                 // Show "Next" button as top app bar action on Medium and Expanded layouts
                 ProvideAppBarActions(
-                    shouldShowActions = windowWidthSize != WindowWidthSizeClass.Compact
+                    shouldShowActions = !isCompactLayout
                 ) {
                     Button(
                         onClick = {
@@ -95,7 +98,7 @@ fun FmlNavHost(
                 }
 
                 SelectRuleTypeScreen(
-                    showNextButton = windowWidthSize == WindowWidthSizeClass.Compact,
+                    showNextButton = isCompactLayout,
                     onSelectedMutationTypeChanged = { selectedOption ->
                         viewModel.updateSelectedMutationType(
                             selection = MutationType.valueOf(selectedOption.id)
@@ -112,16 +115,37 @@ fun FmlNavHost(
 
             composable(route = FmlScreen.AddRule.route) { navBackStackEntry ->
                 val viewModel = navBackStackEntry.sharedViewModel<AddRuleViewModel>(navController)
+                val isCompactLayout = windowWidthSize == WindowWidthSizeClass.Compact
+
+                fun popCurrentNavGraph() {
+                    navController.popBackStack(
+                        route = NestedNavGraphParent.NewRuleFlow.route,
+                        inclusive = true
+                    )
+                }
+
+                ProvideAppBarActions {
+                    if (!isCompactLayout) {
+                        Button(
+                            onClick = { popCurrentNavGraph() }
+                        ) {
+                            Text(text = stringResource(id = R.string.save))
+                        }
+                    }
+
+                    OverflowMenu {
+                        HintsDropdownItem(
+                            isChecked = true,
+                            onClick = { /*TODO*/ },
+                            onCheckedChange = {}
+                        )
+                    }
+                }
 
                 AddRuleScreen(
                     mutationType = viewModel.mutationType.collectAsStateWithLifecycle().value,
-                    showSaveButton = windowWidthSize == WindowWidthSizeClass.Compact,
-                    onSaveClick = {
-                        navController.popBackStack(
-                            route = NestedNavGraphParent.NewRuleFlow.route,
-                            inclusive = true
-                        )
-                    }
+                    showSaveButton = isCompactLayout,
+                    onSaveClick = { popCurrentNavGraph() }
                 )
             }
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.material.icons.outlined.LibraryBooks
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.suvanl.fixmylinks.R
 
 sealed class FmlScreen(
@@ -60,9 +62,16 @@ sealed class FmlScreen(
     )
 
     data object AddRule : FmlScreen(
-        route = "add_rule",
-        label = R.string.add_new_rule
-    )
+        route = "add_rule", label = R.string.add_new_rule
+    ), FmlScreenWithArgs {
+        const val mutationTypeArg = "mutation_type"
+
+        override val args: List<NamedNavArgument> = listOf(
+            navArgument(mutationTypeArg) { type = NavType.StringType }
+        )
+
+        override val routeWithArgs: String = "$route/{$mutationTypeArg}"
+    }
 }
 
 val allFmlScreens = setOf(
@@ -80,3 +89,11 @@ val addNewRuleFlowScreens = setOf(
     FmlScreen.SelectRuleType,
     FmlScreen.AddRule
 )
+
+/**
+ * Returns the base of a route (i.e., the route without any arguments)
+ */
+fun getBaseRoute(route: String?): String {
+    if (route == null) return ""
+    return route.split("/")[0]
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.spring
 import androidx.navigation.NavBackStackEntry
 import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.navigation.addNewRuleFlowScreens
+import com.suvanl.fixmylinks.ui.navigation.getBaseRoute
 
 enum class NavigationEnterTransitionMode { ENTER, POP_ENTER }
 enum class NavigationExitTransitionMode { EXIT, POP_EXIT }
@@ -22,16 +23,19 @@ fun exitNavigationTransition(
     transitionMode: NavigationExitTransitionMode,
     transitionScope: AnimatedContentTransitionScope<NavBackStackEntry>
 ): ExitTransition {
+    val initialDestinationRoute = getBaseRoute(transitionScope.initialState.destination.route)
+    val targetDestinationRoute = getBaseRoute(transitionScope.targetState.destination.route)
+
     // Whether we're navigating from a screen within the "add new rule" flow to a top-level screen
     // that has a FAB
     val isNavigatingFromFlowToTopLevelScreen =
-        addNewRuleFlowScreens.any { it.route == transitionScope.initialState.destination.route }
-                && screensWithFab.any { it.route == transitionScope.targetState.destination.route }
+        addNewRuleFlowScreens.any { it.route == initialDestinationRoute }
+                && screensWithFab.any { it.route == targetDestinationRoute }
 
     // If the target destination is part of the "add new rule" flow, or if we're navigating back to
     // a screen that this flow could've been started from
     return if (
-        addNewRuleFlowScreens.any { it.route == transitionScope.targetState.destination.route }
+        addNewRuleFlowScreens.any { it.route == targetDestinationRoute }
         || isNavigatingFromFlowToTopLevelScreen
     ) {
         // Perform slide out animation when navigating from an initial state of a screen that is
@@ -74,16 +78,19 @@ fun enterNavigationTransition(
     transitionMode: NavigationEnterTransitionMode,
     transitionScope: AnimatedContentTransitionScope<NavBackStackEntry>
 ): EnterTransition {
+    val initialDestinationRoute = getBaseRoute(transitionScope.initialState.destination.route)
+    val targetDestinationRoute = getBaseRoute(transitionScope.targetState.destination.route)
+
     // If we're navigating from a destination with the FAB to a destination in the "add new rule"
     // flow, or if we're performing intra-flow navigation, use the slide animation
     val isNavigatingFromTopLevelDestinationToFlow =
-        screensWithFab.any { it.route == transitionScope.initialState.destination.route }
-                && addNewRuleFlowScreens.any { it.route == transitionScope.targetState.destination.route }
+        screensWithFab.any { it.route == initialDestinationRoute }
+                && addNewRuleFlowScreens.any { it.route == targetDestinationRoute }
 
     // Inverse of isNavigatingFromTopLevelDestinationToFlow
     val isNavigatingFromFlowToTopLevelDestination =
-        addNewRuleFlowScreens.any { it.route == transitionScope.initialState.destination.route }
-                && screensWithFab.any { it.route == transitionScope.targetState.destination.route }
+        addNewRuleFlowScreens.any { it.route == initialDestinationRoute }
+                && screensWithFab.any { it.route == targetDestinationRoute }
 
     return if (
         isNavigatingFromTopLevelDestinationToFlow || isNavigatingFromFlowToTopLevelDestination

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -38,6 +38,7 @@ import com.suvanl.fixmylinks.ui.components.appbar.TopAppBarSize
 import com.suvanl.fixmylinks.ui.navigation.FmlNavHost
 import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.navigation.allFmlScreens
+import com.suvanl.fixmylinks.ui.navigation.getBaseRoute
 import com.suvanl.fixmylinks.ui.navigation.navigateSingleTop
 import com.suvanl.fixmylinks.ui.theme.FixMyLinksTheme
 
@@ -54,7 +55,8 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
-    val currentScreen = allFmlScreens.find { currentDestination?.route == it.route }
+    val currentBaseRoute = getBaseRoute(currentDestination?.route)
+    val currentScreen = allFmlScreens.find { currentBaseRoute == it.route }
 
     // The screens on which the Floating Action Button (FAB) should be displayed
     val displayFabOn = listOf(FmlScreen.Home, FmlScreen.Rules)
@@ -76,15 +78,15 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
         WindowWidthSizeClass.Medium -> true
         WindowWidthSizeClass.Expanded -> true
         else -> false
-    } && hideNavBarOn.none { it.route == currentDestination?.route }
+    } && hideNavBarOn.none { it.route == currentBaseRoute }
 
     val shouldShowNavBar = when (windowSize.widthSizeClass) {
         WindowWidthSizeClass.Compact -> true
         else -> false
-    } && hideNavBarOn.none { it.route == currentDestination?.route }
+    } && hideNavBarOn.none { it.route == currentBaseRoute }
 
-    val shouldShowTopAppBar = hideNavBarOn.any { it.route == currentDestination?.route }
-    val shouldShowFab = displayFabOn.any { it.route == currentDestination?.route }
+    val shouldShowTopAppBar = hideNavBarOn.any { it.route == currentBaseRoute }
+    val shouldShowFab = displayFabOn.any { it.route == currentBaseRoute }
 
     FixMyLinksTheme {
         Scaffold(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -1,57 +1,147 @@
 package com.suvanl.fixmylinks.ui.screens.newruleflow
 
 import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Backup
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.ui.components.form.DomainNameRuleForm
+import com.suvanl.fixmylinks.ui.components.list.SwitchList
+import com.suvanl.fixmylinks.ui.components.list.SwitchListItemState
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+/**
+ * The amount of vertical space between form fields
+ */
+private val interFieldSpacing = 12.dp
 
 @Composable
 fun AddRuleScreen(
+    showSaveButton: Boolean,
     mutationType: MutationType,
-    onDoneClick: () -> Unit,
+    onSaveClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var isRuleEnabled by rememberSaveable { mutableStateOf(true) }
+    var isBackupEnabled by rememberSaveable { mutableStateOf(false) }
+
+    val ruleOptions = listOf(
+        SwitchListItemState(
+            headlineText = stringResource(id = R.string.enable),
+            supportingText = "Start applying this rule now",
+            leadingIcon = Icons.Outlined.CheckCircle,
+            isSwitchChecked = isRuleEnabled,
+            onSwitchCheckedChange = { isRuleEnabled = it }
+        ),
+        SwitchListItemState(
+            headlineText = "Backup to cloud",
+            supportingText = "Sync rule across signed-in devices",
+            leadingIcon = Icons.Outlined.Backup,
+            isSwitchChecked = isBackupEnabled,
+            onSwitchCheckedChange = { isBackupEnabled = it },
+        )
+    )
+
+    AddRuleScreenBody(
+        mutationType = mutationType,
+        showSaveButton = showSaveButton,
+        ruleOptions = ruleOptions,
+        onSaveClick = onSaveClick,
+        modifier = modifier
+    ) {
+        DomainNameRuleForm(
+            interFieldSpacing = interFieldSpacing,
+            onRuleNameChange = {},
+            onInitialDomainNameChange = {},
+            onTargetDomainNameChange = {},
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun AddRuleScreenBody(
+    mutationType: MutationType,
+    showSaveButton: Boolean,
+    ruleOptions: List<SwitchListItemState>,
+    onSaveClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    form: @Composable () -> Unit,
+) {
     Column(
+        verticalArrangement = Arrangement.SpaceBetween,
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .semantics { contentDescription = "Add Rule Screen" }
+            .padding(horizontal = 16.dp)
+            .padding(top = 16.dp)
     ) {
-        Spacer(modifier = Modifier.height(16.dp))
-
         Text(
-            text = "Add a new ${mutationType.name} rule",
-            modifier = modifier.padding(horizontal = 16.dp)
+            text = "Let's create a new ${mutationType.name} rule",
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary
         )
 
-        Button(onClick = onDoneClick) {
-            Text(text = "Done")
+        Spacer(modifier = Modifier.height(8.dp))
+
+        form()
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        SwitchList(items = ruleOptions)
+
+        if (showSaveButton) {
+            Spacer(modifier = Modifier.weight(1F))
+
+            Row(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Button(
+                    onClick = onSaveClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .navigationBarsPadding()
+                        .padding(vertical = 32.dp, horizontal = 8.dp)
+                ) {
+                    Text(text = stringResource(id = R.string.save))
+                }
+            }
         }
     }
 }
 
 @Preview(
     showBackground = true,
-    widthDp = 320
+    widthDp = 400
 )
 @Preview(
     name = "Dark",
     showBackground = true,
-    widthDp = 320,
+    widthDp = 400,
     uiMode = Configuration.UI_MODE_NIGHT_YES
 )
 @Composable
@@ -59,7 +149,8 @@ fun AddRuleScreenPreview() {
     PreviewContainer {
         AddRuleScreen(
             mutationType = MutationType.URL_PARAMS_SPECIFIC,
-            onDoneClick = { }
+            showSaveButton = true,
+            onSaveClick = { },
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -43,6 +43,7 @@ import com.suvanl.fixmylinks.ui.components.list.SwitchList
 import com.suvanl.fixmylinks.ui.components.list.SwitchListItemState
 import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.viewmodel.newruleflow.AddAllUrlParamsRuleViewModel
 import com.suvanl.fixmylinks.viewmodel.newruleflow.AddDomainNameRuleViewModel
 import com.suvanl.fixmylinks.viewmodel.newruleflow.AddSpecificUrlParamsRuleViewModel
 
@@ -100,10 +101,16 @@ fun AddRuleScreen(
             }
 
             MutationType.URL_PARAMS_ALL -> {
+                val viewModel = viewModel<AddAllUrlParamsRuleViewModel>()
+                val ruleNameText by viewModel.ruleName.collectAsStateWithLifecycle()
+                val domainNameText by viewModel.domainName.collectAsStateWithLifecycle()
+
                 AllUrlParamsRuleForm(
                     showHints = showFormFieldHints,
-                    onRuleNameChange = {},
-                    onDomainNameChange = {},
+                    ruleNameText = ruleNameText,
+                    domainNameText = domainNameText,
+                    onRuleNameChange = viewModel::setRuleName,
+                    onDomainNameChange = viewModel::setDomainName,
                 )
             }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.ui.components.form.AllUrlParamsRuleForm
@@ -41,6 +43,7 @@ import com.suvanl.fixmylinks.ui.components.list.SwitchList
 import com.suvanl.fixmylinks.ui.components.list.SwitchListItemState
 import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.viewmodel.newruleflow.AddSpecificUrlParamsRuleViewModel
 
 /**
  * The amount of vertical space between form fields
@@ -104,23 +107,29 @@ fun AddRuleScreen(
             }
 
             MutationType.URL_PARAMS_SPECIFIC -> {
+                val viewModel = viewModel<AddSpecificUrlParamsRuleViewModel>()
+                val ruleNameText by viewModel.ruleName.collectAsStateWithLifecycle()
+                val domainNameText by viewModel.domainName.collectAsStateWithLifecycle()
+                val addedParamNames by viewModel.removableParams.collectAsStateWithLifecycle()
+
                 var openParamNameDialog by remember { mutableStateOf(false) }
-                var addedParamNames by rememberSaveable { mutableStateOf<List<String>>(listOf()) }
 
                 SpecificUrlParamsRuleForm(
                     showHints = showFormFieldHints,
                     interFieldSpacing = interFieldSpacing,
                     addedParamNames = addedParamNames,
-                    onRuleNameChange = {},
-                    onDomainNameChange = {},
+                    ruleNameText = ruleNameText,
+                    domainNameText = domainNameText,
+                    onRuleNameChange = viewModel::setRuleName,
+                    onDomainNameChange = viewModel::setDomainName,
                     onClickAddParam = { openParamNameDialog = true },
-                    onClickDismissParam = {}
+                    onClickDismissParam = viewModel::removeParam,
                 )
 
                 if (openParamNameDialog) {
                     AddParameterNameDialog(
                         onConfirmation = {
-                            addedParamNames += it
+                            viewModel.addParam(it)
                             openParamNameDialog = false
                         },
                         onDismissRequest = { openParamNameDialog = false }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -16,12 +16,15 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Backup
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -33,8 +36,10 @@ import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.ui.components.form.AllUrlParamsRuleForm
 import com.suvanl.fixmylinks.ui.components.form.DomainNameRuleForm
 import com.suvanl.fixmylinks.ui.components.form.SpecificUrlParamsRuleForm
+import com.suvanl.fixmylinks.ui.components.form.common.ParameterNameField
 import com.suvanl.fixmylinks.ui.components.list.SwitchList
 import com.suvanl.fixmylinks.ui.components.list.SwitchListItemState
+import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 
 /**
@@ -99,15 +104,28 @@ fun AddRuleScreen(
             }
 
             MutationType.URL_PARAMS_SPECIFIC -> {
+                var openParamNameDialog by remember { mutableStateOf(false) }
+                var addedParamNames by rememberSaveable { mutableStateOf<List<String>>(listOf()) }
+
                 SpecificUrlParamsRuleForm(
                     showHints = showFormFieldHints,
                     interFieldSpacing = interFieldSpacing,
-                    addedParamNames = listOf("TODO"),
+                    addedParamNames = addedParamNames,
                     onRuleNameChange = {},
                     onDomainNameChange = {},
-                    onClickAddParam = {},
-                    onClickDismissParam = {},
+                    onClickAddParam = { openParamNameDialog = true },
+                    onClickDismissParam = {}
                 )
+
+                if (openParamNameDialog) {
+                    AddParameterNameDialog(
+                        onConfirmation = {
+                            addedParamNames += it
+                            openParamNameDialog = false
+                        },
+                        onDismissRequest = { openParamNameDialog = false }
+                    )
+                }
             }
 
             MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
@@ -184,6 +202,47 @@ private fun AddRuleScreenBody(
     }
 }
 
+@Composable
+private fun AddParameterNameDialog(
+    onConfirmation: (String) -> Unit,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var text by remember { mutableStateOf("") }
+
+    AlertDialog(
+        title = {
+            Text(
+                text = "Add parameter",
+                letterSpacing = LetterSpacingDefaults.Tighter
+            )
+        },
+        text = {
+            ParameterNameField(
+                text = text,
+                onValueChange = { text = it },
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        onDismissRequest = onDismissRequest,
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirmation(text) }
+            ) {
+                Text("Add")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismissRequest
+            ) {
+                Text("Cancel")
+            }
+        },
+        modifier = modifier
+    )
+}
+
 @Preview(
     showBackground = true,
     widthDp = 400
@@ -195,7 +254,7 @@ private fun AddRuleScreenBody(
     uiMode = Configuration.UI_MODE_NIGHT_YES
 )
 @Composable
-fun AddRuleScreenPreview() {
+private fun AddRuleScreenPreview() {
     PreviewContainer {
         AddRuleScreen(
             mutationType = MutationType.URL_PARAMS_SPECIFIC,
@@ -203,5 +262,13 @@ fun AddRuleScreenPreview() {
             showFormFieldHints = true,
             onSaveClick = { },
         )
+    }
+}
+
+@Preview(widthDp = 400)
+@Composable
+private fun AddParameterNameDialogPreview() {
+    PreviewContainer {
+        AddParameterNameDialog(onConfirmation = {}, onDismissRequest = {})
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -29,7 +30,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.ui.components.form.AllUrlParamsRuleForm
 import com.suvanl.fixmylinks.ui.components.form.DomainNameRuleForm
+import com.suvanl.fixmylinks.ui.components.form.SpecificUrlParamsRuleForm
 import com.suvanl.fixmylinks.ui.components.list.SwitchList
 import com.suvanl.fixmylinks.ui.components.list.SwitchListItemState
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
@@ -74,14 +77,52 @@ fun AddRuleScreen(
         onSaveClick = onSaveClick,
         modifier = modifier
     ) {
-        DomainNameRuleForm(
-            showHints = showFormFieldHints,
-            interFieldSpacing = interFieldSpacing,
-            onRuleNameChange = {},
-            onInitialDomainNameChange = {},
-            onTargetDomainNameChange = {},
-            modifier = Modifier.fillMaxWidth()
-        )
+        when (mutationType) {
+            MutationType.DOMAIN_NAME -> {
+                DomainNameRuleForm(
+                    showHints = showFormFieldHints,
+                    interFieldSpacing = interFieldSpacing,
+                    onRuleNameChange = {},
+                    onInitialDomainNameChange = {},
+                    onTargetDomainNameChange = {},
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            MutationType.URL_PARAMS_ALL -> {
+                AllUrlParamsRuleForm(
+                    showHints = showFormFieldHints,
+                    interFieldSpacing = interFieldSpacing,
+                    onRuleNameChange = {},
+                    onDomainNameChange = {},
+                )
+            }
+
+            MutationType.URL_PARAMS_SPECIFIC -> {
+                SpecificUrlParamsRuleForm(
+                    showHints = showFormFieldHints,
+                    interFieldSpacing = interFieldSpacing,
+                    addedParamNames = listOf("TODO"),
+                    onRuleNameChange = {},
+                    onDomainNameChange = {},
+                    onClickAddParam = {},
+                    onClickDismissParam = {},
+                )
+            }
+
+            MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
+                DomainNameRuleForm(
+                    showHints = showFormFieldHints,
+                    interFieldSpacing = interFieldSpacing,
+                    onRuleNameChange = {},
+                    onInitialDomainNameChange = {},
+                    onTargetDomainNameChange = {},
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            else -> Text(text = "Unselectable mutation type - ${mutationType.name}")
+        }
     }
 }
 
@@ -101,6 +142,7 @@ private fun AddRuleScreenBody(
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 16.dp)
             .padding(top = 16.dp)
+            .imePadding()
     ) {
         Text(
             text = "Let's create a new ${mutationType.name} rule",

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -45,11 +45,6 @@ import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 import com.suvanl.fixmylinks.viewmodel.newruleflow.AddSpecificUrlParamsRuleViewModel
 
-/**
- * The amount of vertical space between form fields
- */
-private val interFieldSpacing = 12.dp
-
 @Composable
 fun AddRuleScreen(
     showSaveButton: Boolean,
@@ -89,7 +84,6 @@ fun AddRuleScreen(
             MutationType.DOMAIN_NAME -> {
                 DomainNameRuleForm(
                     showHints = showFormFieldHints,
-                    interFieldSpacing = interFieldSpacing,
                     onRuleNameChange = {},
                     onInitialDomainNameChange = {},
                     onTargetDomainNameChange = {},
@@ -100,7 +94,6 @@ fun AddRuleScreen(
             MutationType.URL_PARAMS_ALL -> {
                 AllUrlParamsRuleForm(
                     showHints = showFormFieldHints,
-                    interFieldSpacing = interFieldSpacing,
                     onRuleNameChange = {},
                     onDomainNameChange = {},
                 )
@@ -116,7 +109,6 @@ fun AddRuleScreen(
 
                 SpecificUrlParamsRuleForm(
                     showHints = showFormFieldHints,
-                    interFieldSpacing = interFieldSpacing,
                     addedParamNames = addedParamNames,
                     ruleNameText = ruleNameText,
                     domainNameText = domainNameText,
@@ -140,7 +132,6 @@ fun AddRuleScreen(
             MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
                 DomainNameRuleForm(
                     showHints = showFormFieldHints,
-                    interFieldSpacing = interFieldSpacing,
                     onRuleNameChange = {},
                     onInitialDomainNameChange = {},
                     onTargetDomainNameChange = {},

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -42,6 +42,7 @@ private val interFieldSpacing = 12.dp
 @Composable
 fun AddRuleScreen(
     showSaveButton: Boolean,
+    showFormFieldHints: Boolean,
     mutationType: MutationType,
     onSaveClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -74,6 +75,7 @@ fun AddRuleScreen(
         modifier = modifier
     ) {
         DomainNameRuleForm(
+            showHints = showFormFieldHints,
             interFieldSpacing = interFieldSpacing,
             onRuleNameChange = {},
             onInitialDomainNameChange = {},
@@ -156,6 +158,7 @@ fun AddRuleScreenPreview() {
         AddRuleScreen(
             mutationType = MutationType.URL_PARAMS_SPECIFIC,
             showSaveButton = true,
+            showFormFieldHints = true,
             onSaveClick = { },
         )
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -43,6 +43,7 @@ import com.suvanl.fixmylinks.ui.components.list.SwitchList
 import com.suvanl.fixmylinks.ui.components.list.SwitchListItemState
 import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.viewmodel.newruleflow.AddDomainNameRuleViewModel
 import com.suvanl.fixmylinks.viewmodel.newruleflow.AddSpecificUrlParamsRuleViewModel
 
 @Composable
@@ -82,12 +83,19 @@ fun AddRuleScreen(
     ) {
         when (mutationType) {
             MutationType.DOMAIN_NAME -> {
+                val viewModel = viewModel<AddDomainNameRuleViewModel>()
+                val ruleNameText by viewModel.ruleName.collectAsStateWithLifecycle()
+                val initialDomainNameText by viewModel.initialDomainName.collectAsStateWithLifecycle()
+                val targetDomainNameText by viewModel.targetDomainName.collectAsStateWithLifecycle()
+
                 DomainNameRuleForm(
                     showHints = showFormFieldHints,
-                    onRuleNameChange = {},
-                    onInitialDomainNameChange = {},
-                    onTargetDomainNameChange = {},
-                    modifier = Modifier.fillMaxWidth()
+                    ruleNameText = ruleNameText,
+                    initialDomainNameText = initialDomainNameText,
+                    targetDomainNameText = targetDomainNameText,
+                    onRuleNameChange = viewModel::setRuleName,
+                    onInitialDomainNameChange = viewModel::setInitialDomainName,
+                    onTargetDomainNameChange = viewModel::setTargetDomainName,
                 )
             }
 
@@ -130,12 +138,21 @@ fun AddRuleScreen(
             }
 
             MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
+                val viewModel = viewModel<AddDomainNameRuleViewModel>()
+                viewModel.setRemoveAllUrlParams(true)
+
+                val ruleNameText by viewModel.ruleName.collectAsStateWithLifecycle()
+                val initialDomainNameText by viewModel.initialDomainName.collectAsStateWithLifecycle()
+                val targetDomainNameText by viewModel.targetDomainName.collectAsStateWithLifecycle()
+
                 DomainNameRuleForm(
                     showHints = showFormFieldHints,
-                    onRuleNameChange = {},
-                    onInitialDomainNameChange = {},
-                    onTargetDomainNameChange = {},
-                    modifier = Modifier.fillMaxWidth()
+                    ruleNameText = ruleNameText,
+                    initialDomainNameText = initialDomainNameText,
+                    targetDomainNameText = targetDomainNameText,
+                    onRuleNameChange = viewModel::setRuleName,
+                    onInitialDomainNameChange = viewModel::setInitialDomainName,
+                    onTargetDomainNameChange = viewModel::setTargetDomainName,
                 )
             }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -112,7 +112,13 @@ private fun AddRuleScreenBody(
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        SwitchList(items = ruleOptions)
+        SwitchList(
+            items = ruleOptions,
+            modifier = Modifier
+                .then(
+                    if (!showSaveButton) Modifier.padding(bottom = 32.dp) else Modifier
+                )
+        )
 
         if (showSaveButton) {
             Spacer(modifier = Modifier.weight(1F))

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -52,14 +52,14 @@ fun AddRuleScreen(
     val ruleOptions = listOf(
         SwitchListItemState(
             headlineText = stringResource(id = R.string.enable),
-            supportingText = "Start applying this rule now",
+            supportingText = stringResource(R.string.enable_rule_supporting_text),
             leadingIcon = Icons.Outlined.CheckCircle,
             isSwitchChecked = isRuleEnabled,
             onSwitchCheckedChange = { isRuleEnabled = it }
         ),
         SwitchListItemState(
-            headlineText = "Backup to cloud",
-            supportingText = "Sync rule across signed-in devices",
+            headlineText = stringResource(R.string.backup_to_cloud),
+            supportingText = stringResource(R.string.backup_to_cloud_supporting_text),
             leadingIcon = Icons.Outlined.Backup,
             isSwitchChecked = isBackupEnabled,
             onSwitchCheckedChange = { isBackupEnabled = it },

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/SelectRuleTypeScreen.kt
@@ -4,8 +4,10 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -68,7 +70,8 @@ fun SelectRuleTypeScreen(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(vertical = 24.dp, horizontal = 8.dp)
+            .padding(horizontal = 8.dp)
+            .padding(top = 16.dp)
             .semantics { contentDescription = "Select Rule Type Screen" },
         verticalArrangement = Arrangement.SpaceBetween
     ) {
@@ -83,15 +86,16 @@ fun SelectRuleTypeScreen(
         // in cases where this button is provided inside the Top App Bar instead, i.e.,
         // medium and expanded layouts.
         if (showNextButton) {
+            Spacer(modifier = Modifier.weight(1F))
+
             Row(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .weight(1F, fill = false)
+                modifier = modifier.fillMaxWidth()
             ) {
                 Button(
                     onClick = onNextButtonClick,
                     modifier = modifier
                         .fillMaxWidth()
+                        .navigationBarsPadding()
                         .padding(bottom = 32.dp)
                         .padding(horizontal = 8.dp)
                 ) {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Theme.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.suvanl.fixmylinks.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -9,10 +8,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 private val LightColors = lightColorScheme(
     primary = md_theme_light_primary,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Type.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Type.kt
@@ -22,7 +22,11 @@ private fun defaultCustomFont(
     )
 }
 
-val TIGHT_LETTER_SPACING = (-0.035F).sp
+object LetterSpacingDefaults {
+    val Tight = (-0.035F).sp
+    val Tighter = Tight.times(8)
+    val ExtraTight = Tight.times(16)
+}
 
 private val defaultTypography = Typography()
 val Typography = Typography(
@@ -86,11 +90,11 @@ val Typography = Typography(
         fontWeight = FontWeight.Normal,
         fontSize = 16.sp,
         lineHeight = 24.sp,
-        letterSpacing = TIGHT_LETTER_SPACING
+        letterSpacing = LetterSpacingDefaults.Tight
     ),
     bodyMedium = defaultTypography.bodyMedium.copy(
         fontFamily = defaultCustomFont(),
-        letterSpacing = TIGHT_LETTER_SPACING
+        letterSpacing = LetterSpacingDefaults.Tight
     ),
     bodySmall = defaultTypography.bodySmall.copy(
         fontFamily = defaultCustomFont()

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Type.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Type.kt
@@ -89,7 +89,8 @@ val Typography = Typography(
         letterSpacing = TIGHT_LETTER_SPACING
     ),
     bodyMedium = defaultTypography.bodyMedium.copy(
-        fontFamily = defaultCustomFont()
+        fontFamily = defaultCustomFont(),
+        letterSpacing = TIGHT_LETTER_SPACING
     ),
     bodySmall = defaultTypography.bodySmall.copy(
         fontFamily = defaultCustomFont()

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Type.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Type.kt
@@ -97,3 +97,7 @@ val Typography = Typography(
     )
 )
 
+object TextStyleDefaults {
+    val dropdownItemStyle = Typography.bodyLarge
+}
+

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/SelectRuleTypeViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/SelectRuleTypeViewModel.kt
@@ -5,8 +5,7 @@ import com.suvanl.fixmylinks.domain.mutation.MutationType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class AddRuleViewModel : ViewModel() {
-
+class SelectRuleTypeViewModel : ViewModel() {
     private val _mutationType = MutableStateFlow(MutationType.DOMAIN_NAME)
     val mutationType = _mutationType.asStateFlow()
 

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
@@ -1,0 +1,22 @@
+package com.suvanl.fixmylinks.viewmodel.newruleflow
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class AddAllUrlParamsRuleViewModel : ViewModel() {
+
+    private val _ruleName = MutableStateFlow("")
+    val ruleName = _ruleName.asStateFlow()
+
+    private val _domainName = MutableStateFlow("")
+    val domainName = _domainName.asStateFlow()
+
+    fun setRuleName(ruleName: String) {
+        _ruleName.value = ruleName
+    }
+
+    fun setDomainName(domainName: String) {
+        _domainName.value = domainName
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
@@ -1,0 +1,35 @@
+package com.suvanl.fixmylinks.viewmodel.newruleflow
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class AddDomainNameRuleViewModel : ViewModel() {
+
+    private val _ruleName = MutableStateFlow("")
+    val ruleName = _ruleName.asStateFlow()
+
+    private val _initialDomainName = MutableStateFlow("")
+    val initialDomainName = _initialDomainName.asStateFlow()
+
+    private val _targetDomainName = MutableStateFlow("")
+    val targetDomainName = _targetDomainName.asStateFlow()
+
+    private val _removeAllUrlParams = MutableStateFlow(false)
+
+    fun setRuleName(ruleName: String) {
+        _ruleName.value = ruleName
+    }
+
+    fun setInitialDomainName(domainName: String) {
+        _initialDomainName.value = domainName
+    }
+
+    fun setTargetDomainName(domainName: String) {
+        _targetDomainName.value = domainName
+    }
+
+    fun setRemoveAllUrlParams(shouldRemove: Boolean) {
+        _removeAllUrlParams.value = shouldRemove
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
@@ -1,0 +1,36 @@
+package com.suvanl.fixmylinks.viewmodel.newruleflow
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class AddSpecificUrlParamsRuleViewModel : ViewModel() {
+
+    private val _ruleName = MutableStateFlow("")
+    val ruleName = _ruleName.asStateFlow()
+
+    private val _domainName = MutableStateFlow("")
+    val domainName = _domainName.asStateFlow()
+
+    private val _removableParams = MutableStateFlow(emptyList<String>())
+    val removableParams = _removableParams.asStateFlow()
+
+    fun setRuleName(ruleName: String) {
+        _ruleName.value = ruleName
+    }
+
+    fun setDomainName(domainName: String) {
+        _domainName.value = domainName
+    }
+
+    fun addParam(paramName: String) {
+        _removableParams.value += paramName
+    }
+
+    fun removeParam(index: Int) {
+        val mutable = _removableParams.value.toMutableList()
+        mutable.removeAt(index)
+
+        _removableParams.value = mutable.toList()
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/SelectRuleTypeViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/SelectRuleTypeViewModel.kt
@@ -1,4 +1,4 @@
-package com.suvanl.fixmylinks.viewmodel
+package com.suvanl.fixmylinks.viewmodel.newruleflow
 
 import androidx.lifecycle.ViewModel
 import com.suvanl.fixmylinks.domain.mutation.MutationType

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,4 +49,5 @@
     <string name="domain_name">Domain name</string>
     <string name="domain_name_supporting_text">The domain name that links of should be affected by this rule.</string>
     <string name="delete">Delete</string>
+    <string name="url_parameter_name">URL parameter name</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,4 +30,15 @@
 
     <string name="empty" />
     <string name="next">Next</string>
+    <string name="enable">Enable</string>
+
+    <string name="rule_name_is_optional_supporting_text">
+        Optional. We\'ll generate a descriptive name for you if you don\'t provide one.
+    </string>
+    <string name="rule_name">Rule name</string>
+    <string name="initial_domain_name">Initial domain name</string>
+    <string name="initial_domain_supporting_text">The domain name of the link that should be changed.\nE.g., <b>x.com</b></string>
+    <string name="target_domain_name">Target domain name</string>
+    <string name="target_domain_supporting_text">The domain name that should replace the original one.\nE.g., <b>twitter.com</b></string>
+    <string name="save">Save</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,4 +46,7 @@
     <string name="backup_to_cloud_supporting_text">Sync rule across signed-in devices</string>
     <string name="content_description_more_options">More options</string>
     <string name="show_hints">Show hints</string>
+    <string name="domain_name">Domain name</string>
+    <string name="domain_name_supporting_text">The domain name that links of should be affected by this rule.</string>
+    <string name="delete">Delete</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,6 @@
     <string name="enable_rule_supporting_text">Start applying this rule now</string>
     <string name="backup_to_cloud">Backup to cloud</string>
     <string name="backup_to_cloud_supporting_text">Sync rule across signed-in devices</string>
+    <string name="content_description_more_options">More options</string>
+    <string name="show_hints">Show hints</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,7 @@
     <string name="target_domain_name">Target domain name</string>
     <string name="target_domain_supporting_text">The domain name that should replace the original one.\nE.g., <b>twitter.com</b></string>
     <string name="save">Save</string>
+    <string name="enable_rule_supporting_text">Start applying this rule now</string>
+    <string name="backup_to_cloud">Backup to cloud</string>
+    <string name="backup_to_cloud_supporting_text">Sync rule across signed-in devices</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id("com.android.application") version "8.1.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.20" apply false
     id("com.guardsquare.appsweep") version "latest.release" apply false
 }


### PR DESCRIPTION
Each selectable/supported MutationType now has a specific form in AddRuleScreen, backed by a ViewModel scoped to the lifecycle of AddRuleScreen (or, technically, the `AddRuleScreenBody` composable), which acts as the form's single source of truth. Supporting text in form fields can be shown/hidden using the "Show hints" option in the top app bar overflow menu. This setting is not currently persisted but will be stored as a preference in a future update.

The selected MutationType on SelectRuleTypeScreen is shared with AddRuleScreen via a navigation argument rather than a shared ViewModel scoped to the lifecycle of the parent nested nav graph. See cf4f380d1402f02d8dae05095f342ac0daf17716 for more info on why this has been done.

Also upgraded to Kotlin v1.9.20 and its associated Compose compiler version (1.5.4).