### PR TITLE
💬 Create and use UiText abstraction for referencing string resources outside of the UI layer

### DIFF
--- a/app/src/androidTest/java/com/suvanl/fixmylinks/SelectRuleTypeScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/SelectRuleTypeScreenTest.kt
@@ -143,7 +143,7 @@ class SelectRuleTypeScreenTest {
     }
 
     @Test
-    fun selectRuleTypeScreen_mediumOrExpanded_nextButton_isDisplayed() {
+    fun selectRuleTypeScreen_mediumOrExpanded_nextButton_doesNotExist() {
         composeTestRule.setContent {
             DefaultMediumExpandedLayout()
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/validation/ValidateDomainNameUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/validation/ValidateDomainNameUseCase.kt
@@ -1,18 +1,21 @@
 package com.suvanl.fixmylinks.domain.validation
 
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.util.UiText
+
 class ValidateDomainNameUseCase(private val domainNameValidator: Validator) {
     operator fun invoke(domainName: String): ValidationResult {
         if (domainName.isBlank()) {
             return ValidationResult(
                 isSuccessful = false,
-                errorMessage = "Domain name can't be blank"
+                errorMessage = UiText.StringResource(R.string.domain_name_blank_error)
             )
         }
 
         if (!domainNameValidator.isValid(domainName)) {
             return ValidationResult(
                 isSuccessful = false,
-                errorMessage = "That doesn't look like a valid domain name"
+                errorMessage = UiText.StringResource(R.string.invalid_domain_name)
             )
         }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/validation/ValidateRemovableParamsListUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/validation/ValidateRemovableParamsListUseCase.kt
@@ -1,11 +1,14 @@
 package com.suvanl.fixmylinks.domain.validation
 
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.util.UiText
+
 class ValidateRemovableParamsListUseCase {
     operator fun invoke(params: List<String>): ValidationResult {
         if (params.isEmpty()) {
             return ValidationResult(
                 isSuccessful = false,
-                errorMessage = "Add at least one URL parameter name"
+                errorMessage = UiText.StringResource(R.string.add_at_least_one_param_name)
             )
         }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/validation/ValidateUrlParamKeyUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/validation/ValidateUrlParamKeyUseCase.kt
@@ -1,11 +1,14 @@
 package com.suvanl.fixmylinks.domain.validation
 
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.util.UiText
+
 class ValidateUrlParamKeyUseCase {
     operator fun invoke(urlParamKey: String): ValidationResult {
         if (urlParamKey.isBlank()) {
             return ValidationResult(
                 isSuccessful = false,
-                errorMessage = "Parameter name can't be blank"
+                errorMessage = UiText.StringResource(R.string.parameter_name_blank_error)
             )
         }
 
@@ -14,7 +17,7 @@ class ValidateUrlParamKeyUseCase {
             if (char !in allowedChars) {
                 return ValidationResult(
                     isSuccessful = false,
-                    errorMessage = "That doesn't look like a valid URL parameter name"
+                    errorMessage = UiText.StringResource(R.string.invalid_parameter_name)
                 )
             }
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/validation/ValidationResult.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/validation/ValidationResult.kt
@@ -1,6 +1,8 @@
 package com.suvanl.fixmylinks.domain.validation
 
+import com.suvanl.fixmylinks.util.UiText
+
 data class ValidationResult(
     val isSuccessful: Boolean,
-    val errorMessage: String? = null,
+    val errorMessage: UiText.StringResource? = null,
 )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
@@ -15,11 +15,12 @@ import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.ui.components.form.common.DomainNameField
 import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.util.UiText
 
 data class AllUrlParamsRuleFormState(
     val ruleName: String = "",
     val domainName: String = "",
-    val domainNameError: String? = null,
+    val domainNameError: UiText? = null,
 )
 
 @Composable
@@ -47,7 +48,7 @@ fun AllUrlParamsRuleForm(
         // "Domain name"
         DomainNameField(
             value = formState.domainName,
-            errorMessage = formState.domainNameError,
+            errorMessage = formState.domainNameError?.asString(),
             showHints = showHints,
             onValueChange = onDomainNameChange,
             isLastFieldInForm = true,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -26,15 +26,16 @@ import com.suvanl.fixmylinks.ui.animation.TransitionDefaults
 import com.suvanl.fixmylinks.ui.components.form.common.FormFieldErrorMessage
 import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.util.UiText
 
 data class DomainNameRuleFormState(
     val ruleName: String = "",
 
     val initialDomainName: String = "",
-    val initialDomainNameError: String? = null,
+    val initialDomainNameError: UiText? = null,
 
     val targetDomainName: String = "",
-    val targetDomainNameError: String? = null,
+    val targetDomainNameError: UiText? = null,
 )
 
 @Composable
@@ -72,7 +73,7 @@ fun DomainNameRuleForm(
                 Column {
                     // Error message
                     if (formState.initialDomainNameError != null) {
-                        FormFieldErrorMessage(text = formState.initialDomainNameError)
+                        FormFieldErrorMessage(text = formState.initialDomainNameError.asString())
                     }
 
                     // Hint text
@@ -111,7 +112,7 @@ fun DomainNameRuleForm(
             supportingText = {
                 Column {
                     if (formState.targetDomainNameError != null) {
-                        FormFieldErrorMessage(text = formState.targetDomainNameError)
+                        FormFieldErrorMessage(text = formState.targetDomainNameError.asString())
                     }
 
                     AnimatedVisibility(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
@@ -38,14 +38,15 @@ import com.suvanl.fixmylinks.ui.components.form.common.DomainNameField
 import com.suvanl.fixmylinks.ui.components.form.common.FormFieldErrorMessage
 import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.util.UiText
 
 data class SpecificUrlParamsRuleFormState(
     val ruleName: String = "",
     val domainName: String = "",
-    val domainNameError: String? = null,
+    val domainNameError: UiText? = null,
     val addedParamNames: List<String> = emptyList(),
-    val addedParamNamesError: String? = null,
-    val urlParamKeyError: String? = null,
+    val addedParamNamesError: UiText? = null,
+    val urlParamKeyError: UiText? = null,
 )
 
 @Composable
@@ -75,7 +76,7 @@ fun SpecificUrlParamsRuleForm(
         // "Domain name"
         DomainNameField(
             value = formState.domainName,
-            errorMessage = formState.domainNameError,
+            errorMessage = formState.domainNameError?.asString(),
             showHints = showHints,
             onValueChange = onDomainNameChange,
             isLastFieldInForm = true,
@@ -107,7 +108,7 @@ fun SpecificUrlParamsRuleForm(
         // Error message
         if (formState.addedParamNamesError != null) {
             FormFieldErrorMessage(
-                text = formState.addedParamNamesError
+                text = formState.addedParamNamesError.asString()
             )
         }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -134,7 +134,7 @@ fun AddRuleScreen(
 
                 if (openParamNameDialog) {
                     AddParameterNameDialog(
-                        textFieldErrorMessage = formUiState.urlParamKeyError,
+                        textFieldErrorMessage = formUiState.urlParamKeyError?.asString(),
                         onConfirmation = {
                             if (!viewModel.validateUrlParamKey(it)) return@AddParameterNameDialog
 

--- a/app/src/main/java/com/suvanl/fixmylinks/util/UiText.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/util/UiText.kt
@@ -1,0 +1,29 @@
+package com.suvanl.fixmylinks.util
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+sealed class UiText {
+    /**
+     * Represents a string that can change based on certain conditions, such as a string from an
+     * API response.
+     */
+    data class DynamicString(val value: String) : UiText()
+
+    /**
+     * Represents an Android string resource.
+     */
+    class StringResource(@StringRes val id: Int, vararg val args: Any) : UiText()
+
+    /**
+     * Returns the text as a string that can be used in the UI
+     */
+    @Composable
+    fun asString(): String {
+        return when (this) {
+            is DynamicString -> value
+            is StringResource -> stringResource(id, *args)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -50,4 +50,9 @@
     <string name="domain_name_supporting_text">The domain name that links of should be affected by this rule.</string>
     <string name="delete">Delete</string>
     <string name="url_parameter_name">URL parameter name</string>
+    <string name="domain_name_blank_error">Domain name can\'t be blank</string>
+    <string name="invalid_domain_name">That doesn\'t look like a valid domain name</string>
+    <string name="parameter_name_blank_error">Parameter name can\'t be blank</string>
+    <string name="invalid_parameter_name">That doesn\'t look like a valid URL parameter name</string>
+    <string name="add_at_least_one_param_name">Add at least one URL parameter name</string>
 </resources>


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

Form validation use cases return an instance of `ValidationResult`, where the `errorMessage` property is a String. While this ensures that the class remains a pure Kotlin class without dependencies on Android libraries or UI layer code, it limits the scope of localisation in the UI, as hardcoded strings cannot be translated. 

The solution to the localisation issue is to use string resources, however, the value of these can only be obtained using `android.content.Context.getString()` (or the `stringResource()` composable in a composable scope). These solutions would result in Android dependencies being introduced in the domain layer which violates the recommended app architecture guidelines.

Therefore, the solution here is to use an abstraction - `UiText`. This sealed class allows us to reference a string resource using its ID and transform it to a String in the UI using the `asString()` composable function. It also supports dynamic text (i.e., text coming from an API response, which is text that the app doesn't own).

## 🧑‍💻 Implementation / changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->

- Create the `UiText` sealed class
- Update form state holder classes to change their `*error` (e.g., `domainNameError`) properties to be of type `UiText`.
- Use the `<UiText>.asString()` composable function to convert the string resource with the given ID to a string that can be displayed in the UI (internally uses the `stringResource()` composable).

## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->

### Automated testing
No additional automated testing was required.

### Manual testing
Verified that the error messages are still shown under the same conditions to ensure that the visual behaviour has not changed.

## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A