### PR TITLE
🚚 Make 'test' and 'androidTest' source sets match 'main' source set's package structure

### DIFF
--- a/app/src/androidTest/java/com/suvanl/fixmylinks/data/local/db/RuleDatabaseTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/data/local/db/RuleDatabaseTest.kt
@@ -1,4 +1,4 @@
-package com.suvanl.fixmylinks
+package com.suvanl.fixmylinks.data.local.db
 
 import android.content.Context
 import androidx.room.Room
@@ -6,7 +6,6 @@ import androidx.room.withTransaction
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
-import com.suvanl.fixmylinks.data.local.db.RuleDatabase
 import com.suvanl.fixmylinks.data.local.db.dao.AllUrlParamsRuleDao
 import com.suvanl.fixmylinks.data.local.db.dao.BaseRuleDao
 import com.suvanl.fixmylinks.data.local.db.dao.DomainNameAndAllUrlParamsRuleDao

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/navigation/NavigationTest.kt
@@ -1,4 +1,4 @@
-package com.suvanl.fixmylinks
+package com.suvanl.fixmylinks.ui.navigation
 
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.ui.platform.LocalContext
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.suvanl.fixmylinks.ui.navigation.FmlNavHost
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/AddRuleScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/AddRuleScreenTest.kt
@@ -1,4 +1,4 @@
-package com.suvanl.fixmylinks
+package com.suvanl.fixmylinks.ui.screens
 
 import androidx.activity.ComponentActivity
 import androidx.compose.material.icons.Icons
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.ui.components.form.AllUrlParamsRuleForm
 import com.suvanl.fixmylinks.ui.components.form.AllUrlParamsRuleFormState

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/SelectRuleTypeScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/SelectRuleTypeScreenTest.kt
@@ -1,4 +1,4 @@
-package com.suvanl.fixmylinks
+package com.suvanl.fixmylinks.ui.screens
 
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/LinkMutationTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/LinkMutationTest.kt
@@ -1,6 +1,5 @@
-package com.suvanl.fixmylinks
+package com.suvanl.fixmylinks.domain.mutation
 
-import com.suvanl.fixmylinks.domain.mutation.MutateUriUseCase
 import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndAllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndSpecificUrlParamsMutationInfo

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
@@ -16,7 +16,7 @@ import java.net.URI
 /**
  * Test suite for link mutation business logic
  */
-class LinkMutationTest {
+class MutateUriUseCaseTest {
 
     private lateinit var mutateUriUseCase: MutateUriUseCase
 


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

Better parity between source sets



## 🧑‍💻 Implementation / changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
- Moved unit test classes to better match the 'main' source set's package structure
  - Renamed LinkMutationTest to MutateUriUseCaseTest, to better describe what exactly is being tested
- Moved instrumented test classes to better match the 'main' source set's package structure

## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
No tests were added. Existing tests' package declaration and imports may have changed, the latter as a result of removing unused imports.


## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A