### PR TITLE
✨ Persist form field hints display preference using Preferences DataStore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
 
     androidTestImplementation("androidx.test:runner:1.5.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("com.google.truth:truth:1.1.4")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("androidx.navigation:navigation-testing:$navVersion")
     androidTestUtil("androidx.test:orchestrator:1.4.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     val navVersion = "2.7.5"
     val roomVersion = "2.6.0"
     val daggerHiltVersion = "2.48.1"
+    val preferencesDataStoreVersion = "1.0.0"
 
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:$lifecycleVersion")
@@ -78,6 +79,8 @@ dependencies {
     implementation("androidx.room:room-runtime:$roomVersion")
     implementation("androidx.room:room-ktx:$roomVersion")
     ksp("androidx.room:room-compiler:$roomVersion")
+
+    implementation("androidx.datastore:datastore-preferences:$preferencesDataStoreVersion")
 
     implementation(platform("androidx.compose:compose-bom:2023.10.01"))
     implementation("androidx.compose.ui:ui")

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/data/repository/UserPreferencesRepositoryTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/data/repository/UserPreferencesRepositoryTest.kt
@@ -1,0 +1,83 @@
+package com.suvanl.fixmylinks.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val TEST_DATASTORE_NAME = "test_preferences_datastore"
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class UserPreferencesRepositoryTest {
+
+    private val testContext: Context = ApplicationProvider.getApplicationContext()
+    private val testCoroutineScope = TestScope()
+    private val testDataStore: DataStore<Preferences> = PreferenceDataStoreFactory.create(
+        scope = testCoroutineScope,
+        produceFile = { testContext.preferencesDataStoreFile(TEST_DATASTORE_NAME) }
+    )
+    private val repository: UserPreferencesRepository = UserPreferencesRepository(testDataStore)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @After
+    fun cleanUp() {
+        testCoroutineScope.launch {
+            testDataStore.edit { it.clear() }
+        }
+
+        testCoroutineScope.cancel()
+    }
+
+    @Test
+    fun repository_testGetAllUserPreferences_asFlow() {
+        val expectedUserPreferences = UserPreferences(
+            showFormFieldHints = true
+        )
+
+        testCoroutineScope.runTest {
+            assertThat(repository.allPreferencesFlow.first())
+                .isEqualTo(expectedUserPreferences)
+        }
+    }
+
+    @Test
+    fun repository_testUpdatePreference_updatesValueIn_allPreferencesFlow() {
+        testCoroutineScope.runTest {
+            repository.updatePreference(SHOW_FORM_FIELD_HINTS, false)
+
+            assertThat(repository.allPreferencesFlow.first().showFormFieldHints)
+                .isEqualTo(false)
+        }
+    }
+
+    companion object {
+        val SHOW_FORM_FIELD_HINTS = PreferenceItem(
+            key = booleanPreferencesKey("show_form_field_hints"),
+            defaultValue = true
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/data/repository/CustomRulesRepository.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/repository/CustomRulesRepository.kt
@@ -121,11 +121,11 @@ class CustomRulesRepository @Inject constructor(
      *
      * **See also**: [Multimap return types](https://d.android.com/training/data-storage/room/relationships#multimap)
      *
-     * @param TSource The type of the Map's value, where the Map is a multimap returned by a
+     * @param TValue The type of the Map's value, where the Map is a multimap returned by a
      *  DAO query function.
-     *  @return A list of domain models ([BaseMutationModel]-derived objects).
+     * @return A list of domain models ([BaseMutationModel]-derived objects).
      */
-    private fun <TSource> Flow<Map<BaseRule, TSource>>.toDomainModelListFlow(): Flow<List<BaseMutationModel>> {
+    private fun <TValue> Flow<Map<BaseRule, TValue>>.toDomainModelListFlow(): Flow<List<BaseMutationModel>> {
         return this.map {
             it.map { (baseRule, genericRule) ->
                 when (genericRule) {

--- a/app/src/main/java/com/suvanl/fixmylinks/data/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/repository/PreferencesRepository.kt
@@ -1,0 +1,28 @@
+package com.suvanl.fixmylinks.data.repository
+
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Represents a preference key-value pair, where the value is the default/fallback value.
+ */
+data class PreferenceItem<T>(
+    val key: Preferences.Key<T>,
+    val defaultValue: T,
+)
+
+interface PreferencesRepository<TPreferences> {
+
+    /**
+     * All preferences as an async observable [Flow], where [TPreferences] is the preferences object
+     * (defined as a data class) that is used throughout the app to represent preference data.
+     */
+    val allPreferencesFlow: Flow<TPreferences>
+
+    /**
+     * Updates the given preferences key with the given new value.
+     * @param preference The preference to update.
+     * @param newValue The new value to assign to the [preference] key.
+     */
+    suspend fun <T> updatePreference(preference: PreferenceItem<T>, newValue: T)
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/repository/UserPreferencesRepository.kt
@@ -1,0 +1,60 @@
+package com.suvanl.fixmylinks.data.repository
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import java.io.IOException
+import javax.inject.Inject
+
+data class UserPreferences(
+    val showFormFieldHints: Boolean = UserPreferencesRepository.SHOW_FORM_FIELD_HINTS.defaultValue,
+)
+
+class UserPreferencesRepository @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) : PreferencesRepository<UserPreferences> {
+    /**
+     * All user preferences ([UserPreferences]) as an async observable [Flow].
+     */
+    override val allPreferencesFlow: Flow<UserPreferences> = dataStore.data
+        .catch { exception ->
+            if (exception !is IOException) throw exception
+
+            exception.printStackTrace()
+            emit(emptyPreferences())
+        }
+        .map { preferences ->
+            mapUserPreferences(preferences)
+        }
+
+    override suspend fun <T> updatePreference(preference: PreferenceItem<T>, newValue: T) {
+        dataStore.edit { preferences ->
+            preferences[preference.key] = newValue
+        }
+    }
+
+    /**
+     * Maps each preference to its associated [UserPreferences] property.
+     * @return An instance of [UserPreferences] containing all stored preferences.
+     */
+    private fun mapUserPreferences(preferences: Preferences): UserPreferences {
+        val showFormFieldHints = preferences[SHOW_FORM_FIELD_HINTS.key]
+            ?: SHOW_FORM_FIELD_HINTS.defaultValue
+
+        return UserPreferences(
+            showFormFieldHints = showFormFieldHints
+        )
+    }
+
+    companion object PreferencesKeys {
+        val SHOW_FORM_FIELD_HINTS = PreferenceItem(
+            key = booleanPreferencesKey("show_form_field_hints"),
+            defaultValue = true
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/di/AppSingletonModule.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/di/AppSingletonModule.kt
@@ -1,6 +1,12 @@
 package com.suvanl.fixmylinks.di
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
 import com.suvanl.fixmylinks.data.local.db.RuleDatabase
 import dagger.Module
 import dagger.Provides
@@ -8,6 +14,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
+
+private const val USER_PREFERENCES = "user_preferences"
 
 /**
  * Provides singleton dependencies that live as long as the application.
@@ -20,5 +28,16 @@ object AppSingletonModule {
     @Singleton
     fun provideRuleDatabase(@ApplicationContext context: Context): RuleDatabase {
         return RuleDatabase.getDatabase(context = context)
+    }
+
+    @Provides
+    @Singleton
+    fun providePreferencesDataStore(@ApplicationContext context: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler(
+                produceNewData = { emptyPreferences() }
+            ),
+            produceFile = { context.preferencesDataStoreFile(name = USER_PREFERENCES) }
+        )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/di/ViewModelModule.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/di/ViewModelModule.kt
@@ -1,7 +1,10 @@
 package com.suvanl.fixmylinks.di
 
 import com.suvanl.fixmylinks.data.repository.CustomRulesRepository
+import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.data.repository.UserPreferences
+import com.suvanl.fixmylinks.data.repository.UserPreferencesRepository
 import com.suvanl.fixmylinks.domain.validation.Validator
 import com.suvanl.fixmylinks.ui.util.DomainNameValidator
 import dagger.Binds
@@ -28,4 +31,10 @@ abstract class ViewModelModule {
     abstract fun bindRulesRepository(
         customRulesRepository: CustomRulesRepository
     ): RulesRepository
+
+    @Binds
+    @ViewModelScoped
+    abstract fun bindPreferencesRepository(
+        userPreferencesRepository: UserPreferencesRepository
+    ): PreferencesRepository<UserPreferences>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -136,6 +136,7 @@ fun FmlNavHost(
                     ?: MutationType.FALLBACK
 
                 val viewModel: AddRuleViewModel = getNewRuleFlowViewModel(mutationType)
+                val userPreferences by viewModel.userPreferences.collectAsStateWithLifecycle()
 
                 val isCompactLayout = windowWidthSize == WindowWidthSizeClass.Compact
                 var hintsOptionCheckedState by remember { mutableStateOf(true) }
@@ -163,8 +164,13 @@ fun FmlNavHost(
 
                     OverflowMenu {
                         HintsDropdownItem(
-                            isChecked = hintsOptionCheckedState,
-                            onCheckedChange = { hintsOptionCheckedState = it }
+                            isChecked = userPreferences.showFormFieldHints,
+                            onCheckedChange = { isChecked ->
+                                coroutineScope.launch {
+                                    viewModel.updateShowHintsPreference(isChecked)
+                                    hintsOptionCheckedState = userPreferences.showFormFieldHints
+                                }
+                            }
                         )
                     }
                 }
@@ -172,7 +178,7 @@ fun FmlNavHost(
                 AddRuleScreen(
                     uiState = AddRuleScreenUiState(
                         mutationType = mutationType,
-                        showFormFieldHints = hintsOptionCheckedState,
+                        showFormFieldHints = userPreferences.showFormFieldHints,
                         showSaveButton = isCompactLayout,
                     ),
                     viewModel = viewModel,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -89,17 +89,19 @@ fun FmlNavHost(
 
                 val isCompactLayout = windowWidthSize == WindowWidthSizeClass.Compact
 
+                fun handleNextButtonClick() {
+                    navController.navigateSingleTop(
+                        route = "${FmlScreen.AddRule.route}/${mutationType.name}",
+                        popUpToStartDestination = false
+                    )
+                }
+
                 // Show "Next" button as top app bar action on Medium and Expanded layouts
                 ProvideAppBarActions(
                     shouldShowActions = !isCompactLayout
                 ) {
                     Button(
-                        onClick = {
-                            navController.navigateSingleTop(
-                                route = FmlScreen.AddRule.route,
-                                popUpToStartDestination = false
-                            )
-                        }
+                        onClick = { handleNextButtonClick() }
                     ) {
                         Text(text = stringResource(id = R.string.next))
                     }
@@ -114,12 +116,7 @@ fun FmlNavHost(
                             selection = MutationType.valueOf(selectedOption.id)
                         )
                     },
-                    onNextButtonClick = {
-                        navController.navigateSingleTop(
-                            route = "${FmlScreen.AddRule.route}/${mutationType.name}",
-                            popUpToStartDestination = false
-                        )
-                    }
+                    onNextButtonClick = { handleNextButtonClick() }
                 )
             }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
@@ -1,6 +1,8 @@
 package com.suvanl.fixmylinks.viewmodel.newruleflow
 
+import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.data.repository.UserPreferences
 import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
@@ -14,8 +16,9 @@ import javax.inject.Inject
 @HiltViewModel
 class AddAllUrlParamsRuleViewModel @Inject constructor(
     private val rulesRepository: Lazy<RulesRepository>,
+    preferencesRepository: Lazy<PreferencesRepository<UserPreferences>>,
     private val validateDomainNameUseCase: ValidateDomainNameUseCase,
-) : AddRuleViewModel() {
+) : AddRuleViewModel(preferencesRepository = preferencesRepository.get()) {
 
     private val _formUiState = MutableStateFlow(AllUrlParamsRuleFormState())
     val formUiState = _formUiState.asStateFlow()

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
@@ -1,6 +1,8 @@
 package com.suvanl.fixmylinks.viewmodel.newruleflow
 
+import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.data.repository.UserPreferences
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndAllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationModel
@@ -15,8 +17,9 @@ import javax.inject.Inject
 @HiltViewModel
 class AddDomainNameRuleViewModel @Inject constructor(
     private val rulesRepository: Lazy<RulesRepository>,
+    preferencesRepository: Lazy<PreferencesRepository<UserPreferences>>,
     private val validateDomainNameUseCase: ValidateDomainNameUseCase
-) : AddRuleViewModel() {
+) : AddRuleViewModel(preferencesRepository = preferencesRepository.get()) {
 
     private val _removeAllUrlParams = MutableStateFlow(false)
 

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
@@ -1,17 +1,50 @@
 package com.suvanl.fixmylinks.viewmodel.newruleflow
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.suvanl.fixmylinks.data.repository.PreferencesRepository
+import com.suvanl.fixmylinks.data.repository.UserPreferences
+import com.suvanl.fixmylinks.data.repository.UserPreferencesRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 
-abstract class AddRuleViewModel : ViewModel() {
+abstract class AddRuleViewModel(
+    private val preferencesRepository: PreferencesRepository<UserPreferences>
+) : ViewModel() {
     /**
-     * Save the rule locally and optionally remotely based on user preferences.
+     * All stored user preferences.
+     */
+    val userPreferences: StateFlow<UserPreferences> = preferencesRepository.allPreferencesFlow
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = TIMEOUT_MILLIS),
+            initialValue = UserPreferences()
+        )
+
+    /**
+     * Saves the rule locally and optionally remotely based on user preferences.
      */
     abstract suspend fun saveRule()
 
     /**
-     * Validate form data.
+     * Validates form data.
      * @return Boolean representing whether validation has passed or not. `true` if data is valid,
      *  else `false`.
      */
     abstract fun validateData(): Boolean
+
+    /**
+     * Updates the user's "Show [[form field]] hints" preference.
+     */
+    suspend fun updateShowHintsPreference(value: Boolean) {
+        preferencesRepository.updatePreference(
+            preference = UserPreferencesRepository.SHOW_FORM_FIELD_HINTS,
+            newValue = value
+        )
+    }
+
+    companion object {
+        private const val TIMEOUT_MILLIS = 5000L
+    }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
@@ -1,6 +1,8 @@
 package com.suvanl.fixmylinks.viewmodel.newruleflow
 
+import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.data.repository.UserPreferences
 import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationInfo
 import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
@@ -16,10 +18,11 @@ import javax.inject.Inject
 @HiltViewModel
 class AddSpecificUrlParamsRuleViewModel @Inject constructor(
     private val rulesRepository: Lazy<RulesRepository>,
+    preferencesRepository: Lazy<PreferencesRepository<UserPreferences>>,
     private val validateDomainNameUseCase: ValidateDomainNameUseCase,
     private val validateRemovableParamsListUseCase: ValidateRemovableParamsListUseCase,
     private val validateUrlParamKeyUseCase: ValidateUrlParamKeyUseCase
-) : AddRuleViewModel() {
+) : AddRuleViewModel(preferencesRepository = preferencesRepository.get()) {
 
     private val _formUiState = MutableStateFlow(SpecificUrlParamsRuleFormState())
     val formUiState = _formUiState.asStateFlow()

--- a/app/src/test/java/com/suvanl/fixmylinks/data/repository/FakePreferencesRepository.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/data/repository/FakePreferencesRepository.kt
@@ -1,0 +1,34 @@
+package com.suvanl.fixmylinks.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakePreferencesRepository : PreferencesRepository<UserPreferences> {
+
+    private var fakePreferences = UserPreferences(
+        showFormFieldHints = true
+    )
+
+    override var allPreferencesFlow: Flow<UserPreferences> = flowOf(fakePreferences)
+
+    override suspend fun <T> updatePreference(preference: PreferenceItem<T>, newValue: T) {
+        when (preference.key.name) {
+            "show_form_field_hints" -> {
+                if (newValue !is Boolean) {
+                    throw IllegalArgumentException(
+                        "Expected newValue to be a Boolean, but got ${newValue!!::class.simpleName}"
+                    )
+                }
+
+                fakePreferences = fakePreferences.copy(showFormFieldHints = newValue)
+            }
+        }
+
+        refreshFlow()
+    }
+
+    private fun refreshFlow() {
+        allPreferencesFlow = flow { emit(fakePreferences) }
+    }
+}

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModelTest.kt
@@ -1,7 +1,10 @@
 package com.suvanl.fixmylinks.viewmodel.newruleflow
 
+import com.suvanl.fixmylinks.data.repository.FakePreferencesRepository
 import com.suvanl.fixmylinks.data.repository.FakeRulesRepository
+import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.data.repository.UserPreferences
 import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
 import com.suvanl.fixmylinks.viewmodel.newruleflow.util.FakeDomainNameValidator
 import kotlinx.coroutines.flow.first
@@ -14,15 +17,18 @@ import org.junit.Test
 class AddAllUrlParamsRuleViewModelTest {
 
     private lateinit var viewModel: AddAllUrlParamsRuleViewModel
-    private lateinit var repository: RulesRepository
+    private lateinit var rulesRepository: RulesRepository
+    private lateinit var preferencesRepository: PreferencesRepository<UserPreferences>
     private lateinit var validateDomainNameUseCase: ValidateDomainNameUseCase
 
     @Before
     fun setup() {
         validateDomainNameUseCase = ValidateDomainNameUseCase(FakeDomainNameValidator())
-        repository = FakeRulesRepository()
+        rulesRepository = FakeRulesRepository()
+        preferencesRepository = FakePreferencesRepository()
         viewModel = AddAllUrlParamsRuleViewModel(
-            rulesRepository = { repository },
+            rulesRepository = { rulesRepository },
+            preferencesRepository = { preferencesRepository },
             validateDomainNameUseCase = validateDomainNameUseCase
         )
     }
@@ -39,7 +45,7 @@ class AddAllUrlParamsRuleViewModelTest {
             viewModel.saveRule()
 
             // Get all rules from the repository
-            val allRules = repository.getAllRules().first()
+            val allRules = rulesRepository.getAllRules().first()
 
             // Assert that the rule exists in the data source
             val rule = allRules.find { it.name == ruleName && it.triggerDomain == domainName }
@@ -56,7 +62,7 @@ class AddAllUrlParamsRuleViewModelTest {
             viewModel.saveRule()
 
             // Get all rules from the repository
-            val allRules = repository.getAllRules().first()
+            val allRules = rulesRepository.getAllRules().first()
 
             // Assert that the rule hasn't been saved in the data source
             val rule = allRules.find { it.name == ruleName }

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModelTest.kt
@@ -1,7 +1,10 @@
 package com.suvanl.fixmylinks.viewmodel.newruleflow
 
+import com.suvanl.fixmylinks.data.repository.FakePreferencesRepository
 import com.suvanl.fixmylinks.data.repository.FakeRulesRepository
+import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.data.repository.UserPreferences
 import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
 import com.suvanl.fixmylinks.viewmodel.newruleflow.util.FakeDomainNameValidator
 import kotlinx.coroutines.flow.first
@@ -15,13 +18,19 @@ class AddDomainNameRuleViewModelTest {
 
     private lateinit var viewModel: AddDomainNameRuleViewModel
     private lateinit var rulesRepository: RulesRepository
+    private lateinit var preferencesRepository: PreferencesRepository<UserPreferences>
     private lateinit var validateDomainNameUseCase: ValidateDomainNameUseCase
 
     @Before
     fun setup() {
         rulesRepository = FakeRulesRepository()
+        preferencesRepository = FakePreferencesRepository()
         validateDomainNameUseCase = ValidateDomainNameUseCase(FakeDomainNameValidator())
-        viewModel = AddDomainNameRuleViewModel({ rulesRepository }, validateDomainNameUseCase)
+        viewModel = AddDomainNameRuleViewModel(
+            rulesRepository = { rulesRepository },
+            preferencesRepository = { preferencesRepository },
+            validateDomainNameUseCase = validateDomainNameUseCase
+        )
     }
 
     @Test

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModelTest.kt
@@ -1,7 +1,10 @@
 package com.suvanl.fixmylinks.viewmodel.newruleflow
 
+import com.suvanl.fixmylinks.data.repository.FakePreferencesRepository
 import com.suvanl.fixmylinks.data.repository.FakeRulesRepository
+import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.data.repository.UserPreferences
 import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
 import com.suvanl.fixmylinks.domain.validation.ValidateRemovableParamsListUseCase
 import com.suvanl.fixmylinks.domain.validation.ValidateUrlParamKeyUseCase
@@ -17,22 +20,25 @@ import org.junit.Test
 class AddSpecificUrlParamsRuleViewModelTest {
 
     private lateinit var viewModel: AddSpecificUrlParamsRuleViewModel
-    private lateinit var repository: RulesRepository
+    private lateinit var rulesRepository: RulesRepository
+    private lateinit var preferencesRepository: PreferencesRepository<UserPreferences>
     private lateinit var validateDomainNameUseCase: ValidateDomainNameUseCase
     private lateinit var validateRemovableParamsListUseCase: ValidateRemovableParamsListUseCase
     private lateinit var validateUrlParamKeyUseCase: ValidateUrlParamKeyUseCase
 
     @Before
     fun setup() {
-        repository = FakeRulesRepository()
+        rulesRepository = FakeRulesRepository()
+        preferencesRepository = FakePreferencesRepository()
         validateDomainNameUseCase = ValidateDomainNameUseCase(FakeDomainNameValidator())
         validateRemovableParamsListUseCase = ValidateRemovableParamsListUseCase()
         validateUrlParamKeyUseCase = ValidateUrlParamKeyUseCase()
         viewModel = AddSpecificUrlParamsRuleViewModel(
-            { repository },
-            validateDomainNameUseCase,
-            validateRemovableParamsListUseCase,
-            validateUrlParamKeyUseCase
+            rulesRepository = { rulesRepository },
+            preferencesRepository = { preferencesRepository },
+            validateDomainNameUseCase = validateDomainNameUseCase,
+            validateRemovableParamsListUseCase = validateRemovableParamsListUseCase,
+            validateUrlParamKeyUseCase = validateUrlParamKeyUseCase
         )
     }
 
@@ -110,7 +116,7 @@ class AddSpecificUrlParamsRuleViewModelTest {
             viewModel.saveRule()
 
             // Get all rules from the repository
-            val allRules = repository.getAllRules().first()
+            val allRules = rulesRepository.getAllRules().first()
 
             // Assert that the rule hasn't been saved in the data source
             val rule = allRules.find { it.name == ruleName }
@@ -132,7 +138,7 @@ class AddSpecificUrlParamsRuleViewModelTest {
             viewModel.saveRule()
 
             // Get all rules from the repository
-            val allRules = repository.getAllRules().first()
+            val allRules = rulesRepository.getAllRules().first()
 
             // Assert that the rule doesn't exist in the data source
             val rule = allRules.find { it.name == ruleName && it.triggerDomain == domainName }
@@ -155,7 +161,7 @@ class AddSpecificUrlParamsRuleViewModelTest {
             viewModel.saveRule()
 
             // Get all rules from the repository
-            val allRules = repository.getAllRules().first()
+            val allRules = rulesRepository.getAllRules().first()
 
             // Assert that the rule exists in the data source
             val rule = allRules.find { it.name == ruleName && it.triggerDomain == domainName }


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

Currently, the value of the "Show hints" preference in the top app bar overflow menu (around AddRuleScreen) isn't persisted, meaning users have to toggle the value every time they use AddRuleScreen if they don't prefer the default behaviour (default = hints are displayed).

This PR solves this by persisting the value of this preference and reading the stored value when on this screen.

## 🧑‍💻 Implementation / changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
- Create UserPreferencesRepository, a repository class that exposes user preferences as a `Flow` to the rest of the app and abstracts away implementation details such as the persistence mechanism used (just Preferences DataStore at the moment)
- Expose the UserPreferences object as a StateFlow at the ViewModel level
  - Collected as state at the NavHost level, since this is where the top app bar actions are provided
  
Not strictly related to preferences (but discovered during manual testing of features implemented in this PR):
- Fixed a bug where clicking the "Next" button that appears in the top app bar in medium/expanded layouts causes the app to crash as it attempts to navigate without providing the required mutation_type navigation argument. Fixed by ensuring this argument is provided in all situations/layouts.


## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
### Unit testing
- Updated ViewModel tests by injecting a fake preferences repository (FakePreferencesRepository) into ViewModel classes that depend on a PreferencesRepository implementation

### Instrumentation testing
- Added an instrumented test for UserPreferencesRepository (UserPreferencesRepositoryTest) which tests the public data/methods exposed by this repository.


## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A