### PR TITLE
🐛 Fix bug where sharing a link containing "www" subdomain and no URL params throws NPE

### DIFF
--- a/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
@@ -12,7 +12,7 @@ object UriUtils {
      */
     fun URI.removeSubdomain(subdomain: String): URI {
         val hostWithoutSubdomain = host.removePrefix("${subdomain}.")
-        val hasUrlParams = rawQuery.isNotEmpty()
+        val hasUrlParams = !rawQuery.isNullOrEmpty()
 
         return MutatedUri(
             scheme = scheme,

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
@@ -212,4 +212,28 @@ class MutateUriUseCaseTest {
 
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun `no rule - link containing 'www' subdomain and no URL params doesn't modify original link`() {
+        val actual = mutateUriUseCase(
+            URI("https://www.framer.com/motion/guide-reduce-bundle-size/"),
+            mockCustomRules
+        )
+        // URI should not change
+        val expected = URI("https://www.framer.com/motion/guide-reduce-bundle-size/")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `built-in rule - link containing 'www' subdomain and no URL params doesn't modify original link`() {
+        val actual = mutateUriUseCase(
+            URI("https://www.open.spotify.com/track/3PRljkcobGtC6Kc3ILLSmq"),
+            mockCustomRules
+        )
+        // URI should not change
+        val expected = URI("https://www.open.spotify.com/track/3PRljkcobGtC6Kc3ILLSmq")
+
+        assertEquals(expected, actual)
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.2" apply false
+    id("com.android.application") version "8.1.4" apply false
     id("org.jetbrains.kotlin.android") version "1.9.20" apply false
     id("com.guardsquare.appsweep") version "latest.release" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

Fixes #47 



## 🧑‍💻 Implementation / changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
- Check whether `<URI>.rawQuery` is null in the `URI.removeSubdomain` extension function (within `UriUtils` object), in addition to the original behaviour of checking whether the `rawQuery` string is empty.


## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
Added unit tests for the scenario being fixed (share URL containing 'www' subdomain and no URL params). The two tests added test this under the following conditions:
- when a rule for the link **doesn't** exist
- when a rule for the link **does** exist


## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A