### PR TITLE
✨ Implement ability to update existing custom rules via the UI

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,16 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/data/local/db/RuleDatabaseTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/data/local/db/RuleDatabaseTest.kt
@@ -438,7 +438,7 @@ class RuleDatabaseTest {
                 title = "twitter.com to x.com",  // said no one ever (other than Husk)
                 authorId = DEFAULT_AUTHOR_ID,
                 mutationType = MutationType.DOMAIN_NAME,
-                triggerDomain = "x.com",
+                triggerDomain = "twitter.com",
                 isLocalOnly = true
             ),
             DomainNameRule(

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/AllUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/AllUrlParamsRuleDao.kt
@@ -33,4 +33,11 @@ interface AllUrlParamsRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id"
     )
     fun getAll(): Flow<Map<BaseRule, AllUrlParamsRule>>
+
+    @Query(
+        "SELECT * FROM all_url_params_rule AS rule " +
+        "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
+        "WHERE rule.base_rule_id = :baseRuleId"
+    )
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndAllUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndAllUrlParamsRuleDao.kt
@@ -33,5 +33,5 @@ interface DomainNameAndAllUrlParamsRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
         "WHERE rule.base_rule_id = :baseRuleId"
     )
-    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, DomainNameAndAllUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndAllUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndAllUrlParamsRuleDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.suvanl.fixmylinks.data.local.db.entity.AllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
 import com.suvanl.fixmylinks.data.local.db.entity.DomainNameAndAllUrlParamsRule
 import kotlinx.coroutines.flow.Flow
@@ -26,4 +27,11 @@ interface DomainNameAndAllUrlParamsRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id"
     )
     fun getAll(): Flow<Map<BaseRule, DomainNameAndAllUrlParamsRule>>
+
+    @Query(
+        "SELECT * FROM domain_name_and_all_url_params_rule AS rule " +
+        "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
+        "WHERE rule.base_rule_id = :baseRuleId"
+    )
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndSpecificUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndSpecificUrlParamsRuleDao.kt
@@ -7,7 +7,6 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
-import com.suvanl.fixmylinks.data.local.db.entity.DomainNameAndAllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.DomainNameAndSpecificUrlParamsRule
 import kotlinx.coroutines.flow.Flow
 
@@ -33,5 +32,5 @@ interface DomainNameAndSpecificUrlParamsRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
         "WHERE rule.base_rule_id = :baseRuleId"
     )
-    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, DomainNameAndAllUrlParamsRule>>
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, DomainNameAndSpecificUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndSpecificUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndSpecificUrlParamsRuleDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.suvanl.fixmylinks.data.local.db.entity.AllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
 import com.suvanl.fixmylinks.data.local.db.entity.DomainNameAndSpecificUrlParamsRule
 import kotlinx.coroutines.flow.Flow
@@ -26,4 +27,11 @@ interface DomainNameAndSpecificUrlParamsRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id"
     )
     fun getAll(): Flow<Map<BaseRule, DomainNameAndSpecificUrlParamsRule>>
+
+    @Query(
+        "SELECT * FROM domain_name_and_specific_url_params_rule AS rule " +
+        "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
+        "WHERE rule.base_rule_id = :baseRuleId"
+    )
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndSpecificUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndSpecificUrlParamsRuleDao.kt
@@ -6,7 +6,6 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import com.suvanl.fixmylinks.data.local.db.entity.AllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
 import com.suvanl.fixmylinks.data.local.db.entity.DomainNameAndAllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.DomainNameAndSpecificUrlParamsRule

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndSpecificUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameAndSpecificUrlParamsRuleDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Query
 import androidx.room.Update
 import com.suvanl.fixmylinks.data.local.db.entity.AllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
+import com.suvanl.fixmylinks.data.local.db.entity.DomainNameAndAllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.DomainNameAndSpecificUrlParamsRule
 import kotlinx.coroutines.flow.Flow
 
@@ -33,5 +34,5 @@ interface DomainNameAndSpecificUrlParamsRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
         "WHERE rule.base_rule_id = :baseRuleId"
     )
-    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, DomainNameAndAllUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameRuleDao.kt
@@ -33,5 +33,5 @@ interface DomainNameRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
         "WHERE rule.base_rule_id = :baseRuleId"
     )
-    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, DomainNameRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameRuleDao.kt
@@ -6,7 +6,6 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import com.suvanl.fixmylinks.data.local.db.entity.AllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
 import com.suvanl.fixmylinks.data.local.db.entity.DomainNameRule
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/DomainNameRuleDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.suvanl.fixmylinks.data.local.db.entity.AllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
 import com.suvanl.fixmylinks.data.local.db.entity.DomainNameRule
 import kotlinx.coroutines.flow.Flow
@@ -26,4 +27,11 @@ interface DomainNameRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id"
     )
     fun getAll(): Flow<Map<BaseRule, DomainNameRule>>
+
+    @Query(
+        "SELECT * FROM domain_name_rule AS rule " +
+        "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
+        "WHERE rule.base_rule_id = :baseRuleId"
+    )
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/SpecificUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/SpecificUrlParamsRuleDao.kt
@@ -6,7 +6,6 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import com.suvanl.fixmylinks.data.local.db.entity.AllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
 import com.suvanl.fixmylinks.data.local.db.entity.SpecificUrlParamsRule
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/SpecificUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/SpecificUrlParamsRuleDao.kt
@@ -6,6 +6,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import com.suvanl.fixmylinks.data.local.db.entity.AllUrlParamsRule
 import com.suvanl.fixmylinks.data.local.db.entity.BaseRule
 import com.suvanl.fixmylinks.data.local.db.entity.SpecificUrlParamsRule
 import kotlinx.coroutines.flow.Flow
@@ -26,4 +27,11 @@ interface SpecificUrlParamsRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id"
     )
     fun getAll(): Flow<Map<BaseRule, SpecificUrlParamsRule>>
+
+    @Query(
+        "SELECT * FROM specific_url_params_rule AS rule " +
+        "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
+        "WHERE rule.base_rule_id = :baseRuleId"
+    )
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/SpecificUrlParamsRuleDao.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/dao/SpecificUrlParamsRuleDao.kt
@@ -33,5 +33,5 @@ interface SpecificUrlParamsRuleDao {
         "JOIN base_rule ON rule.base_rule_id = base_rule.id " +
         "WHERE rule.base_rule_id = :baseRuleId"
     )
-    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, AllUrlParamsRule>>
+    fun getByBaseRuleId(baseRuleId: Long): Flow<Map<BaseRule, SpecificUrlParamsRule>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/repository/RulesRepository.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/repository/RulesRepository.kt
@@ -1,5 +1,6 @@
 package com.suvanl.fixmylinks.data.repository
 
+import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
 import kotlinx.coroutines.flow.Flow
 
@@ -9,6 +10,8 @@ interface RulesRepository {
     suspend fun deleteAllRules()
 
     suspend fun deleteByBaseRuleId(baseRuleId: Long)
+
+    fun getRuleByBaseId(baseRuleId: Long, ruleType: MutationType, ): Flow<BaseMutationModel>
 
     fun getAllRules(): Flow<List<BaseMutationModel>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/repository/RulesRepository.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/repository/RulesRepository.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.flow.Flow
 interface RulesRepository {
     suspend fun saveRule(rule: BaseMutationModel)
 
+    suspend fun updateRule(baseRuleId: Long, newData: BaseMutationModel)
+
     suspend fun deleteAllRules()
 
     suspend fun deleteByBaseRuleId(baseRuleId: Long)
 
-    fun getRuleByBaseId(baseRuleId: Long, ruleType: MutationType, ): Flow<BaseMutationModel>
+    fun getRuleByBaseId(baseRuleId: Long, ruleType: MutationType): Flow<BaseMutationModel>
 
     fun getAllRules(): Flow<List<BaseMutationModel>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/AllUrlParamsMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/AllUrlParamsMutationModel.kt
@@ -12,5 +12,17 @@ data class AllUrlParamsMutationModel(
     override val baseRuleId: Long = 0,
 ) : BaseMutationModel
 
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ */
 fun AllUrlParamsMutationModel.toDatabaseEntity(baseRuleId: Long) =
     AllUrlParamsRule(baseRuleId = baseRuleId)
+
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ * @param ruleId The ID of the rule (its primary key).
+ */
+fun AllUrlParamsMutationModel.toDatabaseEntity(baseRuleId: Long, ruleId: Long) =
+    AllUrlParamsRule(id = ruleId, baseRuleId = baseRuleId)

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/BaseMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/BaseMutationModel.kt
@@ -42,6 +42,7 @@ interface BaseMutationModel {
 }
 
 fun BaseMutationModel.toDatabaseEntity() = BaseRule(
+    id = baseRuleId,
     title = name,
     mutationType = mutationType,
     triggerDomain = triggerDomain,

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameAndAllUrlParamsMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameAndAllUrlParamsMutationModel.kt
@@ -13,8 +13,25 @@ data class DomainNameAndAllUrlParamsMutationModel(
     val mutationInfo: DomainNameMutationInfo
 ) : BaseMutationModel
 
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ */
 fun DomainNameAndAllUrlParamsMutationModel.toDatabaseEntity(baseRuleId: Long) =
     DomainNameAndAllUrlParamsRule(
+        baseRuleId = baseRuleId,
+        initialDomainName = mutationInfo.initialDomain,
+        targetDomainName = mutationInfo.targetDomain,
+    )
+
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ * @param ruleId The ID of the rule (its primary key).
+ */
+fun DomainNameAndAllUrlParamsMutationModel.toDatabaseEntity(baseRuleId: Long, ruleId: Long) =
+    DomainNameAndAllUrlParamsRule(
+        id = ruleId,
         baseRuleId = baseRuleId,
         initialDomainName = mutationInfo.initialDomain,
         targetDomainName = mutationInfo.targetDomain,

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameAndSpecificUrlParamsMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameAndSpecificUrlParamsMutationModel.kt
@@ -19,8 +19,26 @@ data class DomainNameAndSpecificUrlParamsMutationModel(
     val mutationInfo: DomainNameAndSpecificUrlParamsMutationInfo,
 ) : BaseMutationModel
 
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ */
 fun DomainNameAndSpecificUrlParamsMutationModel.toDatabaseEntity(baseRuleId: Long) =
     DomainNameAndSpecificUrlParamsRule(
+        baseRuleId = baseRuleId,
+        initialDomainName = mutationInfo.initialDomainName,
+        targetDomainName = mutationInfo.targetDomainName,
+        removableParams = mutationInfo.removableParams,
+    )
+
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ * @param ruleId The ID of the rule (its primary key).
+ */
+fun DomainNameAndSpecificUrlParamsMutationModel.toDatabaseEntity(baseRuleId: Long, ruleId: Long) =
+    DomainNameAndSpecificUrlParamsRule(
+        id = ruleId,
         baseRuleId = baseRuleId,
         initialDomainName = mutationInfo.initialDomainName,
         targetDomainName = mutationInfo.targetDomainName,

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameMutationModel.kt
@@ -18,7 +18,23 @@ data class DomainNameMutationModel(
     val mutationInfo: DomainNameMutationInfo,
 ) : BaseMutationModel
 
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ */
 fun DomainNameMutationModel.toDatabaseEntity(baseRuleId: Long) = DomainNameRule(
+    baseRuleId = baseRuleId,
+    initialDomainName = mutationInfo.initialDomain,
+    targetDomainName = mutationInfo.targetDomain,
+)
+
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ * @param ruleId The ID of the rule (its primary key).
+ */
+fun DomainNameMutationModel.toDatabaseEntity(baseRuleId: Long, ruleId: Long) = DomainNameRule(
+    id = ruleId,
     baseRuleId = baseRuleId,
     initialDomainName = mutationInfo.initialDomain,
     targetDomainName = mutationInfo.targetDomain,

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/SpecificUrlParamsMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/SpecificUrlParamsMutationModel.kt
@@ -17,7 +17,23 @@ data class SpecificUrlParamsMutationModel(
     val mutationInfo: SpecificUrlParamsMutationInfo,
 ) : BaseMutationModel
 
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ */
 fun SpecificUrlParamsMutationModel.toDatabaseEntity(baseRuleId: Long) = SpecificUrlParamsRule(
     baseRuleId = baseRuleId,
     removableParams = mutationInfo.removableParams,
 )
+
+/**
+ * Transforms this domain model to a database entity.
+ * @param baseRuleId The ID of the rule's related BaseRule.
+ * @param ruleId The ID of the rule (its primary key).
+ */
+fun SpecificUrlParamsMutationModel.toDatabaseEntity(baseRuleId: Long, ruleId: Long) =
+    SpecificUrlParamsRule(
+        id = ruleId,
+        baseRuleId = baseRuleId,
+        removableParams = mutationInfo.removableParams,
+    )

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
@@ -12,7 +12,7 @@ object UriUtils {
      */
     fun URI.removeSubdomain(subdomain: String): URI {
         val hostWithoutSubdomain = host.removePrefix("${subdomain}.")
-        val hasUrlParams = rawQuery.isNotEmpty()
+        val hasUrlParams = !rawQuery.isNullOrEmpty()
 
         return MutatedUri(
             scheme = scheme,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/button/EditFab.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/button/EditFab.kt
@@ -1,0 +1,32 @@
+package com.suvanl.fixmylinks.ui.components.button
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.FloatingActionButtonElevation
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import com.suvanl.fixmylinks.R
+
+@Composable
+fun EditFab(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    elevation: FloatingActionButtonElevation = FloatingActionButtonDefaults.elevation(),
+) {
+    FloatingActionButton(
+        onClick = onClick,
+        elevation = elevation,
+        modifier = modifier.semantics { testTag = "Edit FAB" }
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Edit,
+            contentDescription = stringResource(id = R.string.edit)
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -189,7 +189,14 @@ fun FmlNavHost(
                     if (!viewModel.validateData()) return
 
                     coroutineScope.launch {
-                        viewModel.saveRule()
+                        val isEditing = action == FmlScreen.AddRule.Action.EDIT && baseRuleId != 0L
+
+                        if (isEditing) {
+                            viewModel.updateExistingRule()
+                        } else {
+                            viewModel.saveRule()
+                        }
+
                         navController.popBackStack(
                             route = NestedNavGraphParent.NewRuleFlow.route,
                             inclusive = true

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -168,6 +168,17 @@ fun FmlNavHost(
                 val mutationType = MutationType.entries.find { it.name == mutationTypeArg }
                     ?: MutationType.FALLBACK
 
+                val actionArg = navBackStackEntry.arguments?.getString(FmlScreen.AddRule.actionArg)
+                val action = FmlScreen.AddRule.Action.entries.find { it.name == actionArg }
+                    ?: FmlScreen.AddRule.Action.ADD
+
+                val baseRuleId =
+                    navBackStackEntry.arguments?.getLong(FmlScreen.AddRule.baseRuleIdArg) ?: 0
+
+                if (action == FmlScreen.AddRule.Action.EDIT && baseRuleId == 0L) {
+                    throw IllegalStateException("base_rule_id nav arg cannot be 0 while action is Action.EDIT")
+                }
+
                 val viewModel: AddRuleViewModel = getNewRuleFlowViewModel(mutationType)
                 val userPreferences by viewModel.userPreferences.collectAsStateWithLifecycle()
 
@@ -215,7 +226,9 @@ fun FmlNavHost(
                         showSaveButton = isCompactLayout,
                     ),
                     viewModel = viewModel,
-                    onSaveClick = { handleSaveRuleClick() }
+                    onSaveClick = { handleSaveRuleClick() },
+                    action = action,
+                    baseRuleId = baseRuleId,
                 )
             }
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -192,7 +192,7 @@ fun FmlNavHost(
                         val isEditing = action == FmlScreen.AddRule.Action.EDIT && baseRuleId != 0L
 
                         if (isEditing) {
-                            viewModel.updateExistingRule()
+                            viewModel.updateExistingRule(baseRuleId)
                         } else {
                             viewModel.saveRule()
                         }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -91,22 +91,20 @@ fun FmlNavHost(
             route = FmlScreen.RuleDetails.routeWithArgs,
             arguments = FmlScreen.RuleDetails.args
         ) { navBackStackEntry ->
-            // vm
-
             val mutationTypeArg =
                 navBackStackEntry.arguments?.getString(FmlScreen.RuleDetails.mutationTypeArg)
 
             val mutationType = MutationType.entries.find { it.name == mutationTypeArg }
                 ?: MutationType.FALLBACK
 
-            val baseRuleIdArg =
+            val baseRuleId =
                 navBackStackEntry.arguments?.getLong(FmlScreen.RuleDetails.baseRuleIdArg)
                     ?: throw NullPointerException("Expected base_rule_id to be non-null")
 
             RuleDetailsScreen(
                 mutationType = mutationType,
-                baseRuleId = baseRuleIdArg,
-                onClickEdit = { /*TODO*/ }
+                baseRuleId = baseRuleId,
+                onClickEdit = {}
             )
         }
 
@@ -121,8 +119,15 @@ fun FmlNavHost(
                 val isCompactLayout = windowWidthSize == WindowWidthSizeClass.Compact
 
                 fun handleNextButtonClick() {
+                    // The route used for adding a new rule:
+                    //  - action is Action.ADD
+                    //  - baseRuleId is 0 since one doesn't exist yet. A non-zero value should only
+                    //    be passed as this argument if the action arg is Action.EDIT
+                    val addActionRoute =
+                        "${FmlScreen.AddRule.route}/${mutationType.name}/${FmlScreen.AddRule.Action.ADD}/${0L}"
+
                     navController.navigateSingleTop(
-                        route = "${FmlScreen.AddRule.route}/${mutationType.name}",
+                        route = addActionRoute,
                         popUpToStartDestination = false
                     )
                 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -36,6 +36,7 @@ import com.suvanl.fixmylinks.ui.navigation.transition.exitNavigationTransition
 import com.suvanl.fixmylinks.ui.screens.HomeScreen
 import com.suvanl.fixmylinks.ui.screens.RulesScreen
 import com.suvanl.fixmylinks.ui.screens.SavedScreen
+import com.suvanl.fixmylinks.ui.screens.details.RuleDetailsScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreenUiState
 import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
@@ -72,11 +73,41 @@ fun FmlNavHost(
         }
 
         composable(route = FmlScreen.Rules.route) {
-            RulesScreen()
+            RulesScreen(
+                onClickRuleItem = { mutationType, baseRuleId ->
+                    navController.navigateSingleTop(
+                        route = "${FmlScreen.RuleDetails.route}/${mutationType.name}/${baseRuleId}",
+                        popUpToStartDestination = false
+                    )
+                }
+            )
         }
 
         composable(route = FmlScreen.Saved.route) {
             SavedScreen()
+        }
+
+        composable(
+            route = FmlScreen.RuleDetails.routeWithArgs,
+            arguments = FmlScreen.RuleDetails.args
+        ) { navBackStackEntry ->
+            // vm
+
+            val mutationTypeArg =
+                navBackStackEntry.arguments?.getString(FmlScreen.RuleDetails.mutationTypeArg)
+
+            val mutationType = MutationType.entries.find { it.name == mutationTypeArg }
+                ?: MutationType.FALLBACK
+
+            val baseRuleIdArg =
+                navBackStackEntry.arguments?.getLong(FmlScreen.RuleDetails.baseRuleIdArg)
+                    ?: throw NullPointerException("Expected base_rule_id to be non-null")
+
+            RuleDetailsScreen(
+                mutationType = mutationType,
+                baseRuleId = baseRuleIdArg,
+                onClickEdit = { /*TODO*/ }
+            )
         }
 
         navigation(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
@@ -3,13 +3,13 @@ package com.suvanl.fixmylinks.ui.navigation
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmarks
+import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LibraryBooks
-import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.Bookmarks
+import androidx.compose.material.icons.outlined.Circle
 import androidx.compose.material.icons.outlined.Home
 import androidx.compose.material.icons.outlined.LibraryBooks
-import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NamedNavArgument
 import androidx.navigation.NavType
@@ -19,8 +19,8 @@ import com.suvanl.fixmylinks.R
 sealed class FmlScreen(
     val route: String,
     @StringRes val label: Int,
-    val selectedIcon: ImageVector = Icons.Filled.Star,
-    val unselectedIcon: ImageVector = Icons.Outlined.StarOutline
+    val selectedIcon: ImageVector = Icons.Filled.Circle,
+    val unselectedIcon: ImageVector = Icons.Outlined.Circle
 ) {
     private interface FmlScreenWithArgs {
         /**
@@ -56,21 +56,33 @@ sealed class FmlScreen(
         unselectedIcon = Icons.Outlined.Bookmarks
     )
 
+    data object RuleDetails : FmlScreen(
+        route = "rule_details",
+        label = R.string.rule_details
+    ), FmlScreenWithArgs {
+        const val mutationTypeArg = "mutation_type"
+        const val baseRuleIdArg = "base_rule_id"
+        override val args = listOf(
+            navArgument(mutationTypeArg) { type = NavType.StringType },
+            navArgument(baseRuleIdArg) { type = NavType.LongType }
+        )
+        override val routeWithArgs = "$route/{$mutationTypeArg}/{$baseRuleIdArg}"
+    }
+
     data object SelectRuleType : FmlScreen(
         route = "select_rule_type",
         label = R.string.select_rule_type
     )
 
     data object AddRule : FmlScreen(
-        route = "add_rule", label = R.string.add_new_rule
+        route = "add_rule",
+        label = R.string.add_new_rule
     ), FmlScreenWithArgs {
         const val mutationTypeArg = "mutation_type"
-
-        override val args: List<NamedNavArgument> = listOf(
+        override val args = listOf(
             navArgument(mutationTypeArg) { type = NavType.StringType }
         )
-
-        override val routeWithArgs: String = "$route/{$mutationTypeArg}"
+        override val routeWithArgs = "$route/{$mutationTypeArg}"
     }
 }
 
@@ -79,7 +91,8 @@ val allFmlScreens = setOf(
     FmlScreen.Rules,
     FmlScreen.Saved,
     FmlScreen.SelectRuleType,
-    FmlScreen.AddRule
+    FmlScreen.AddRule,
+    FmlScreen.RuleDetails,
 )
 
 /**

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
@@ -79,10 +79,21 @@ sealed class FmlScreen(
         label = R.string.add_new_rule
     ), FmlScreenWithArgs {
         const val mutationTypeArg = "mutation_type"
+        const val actionArg = "action"
+        const val baseRuleIdArg = "base_rule_id"
+
         override val args = listOf(
-            navArgument(mutationTypeArg) { type = NavType.StringType }
+            navArgument(mutationTypeArg) { type = NavType.StringType },
+            navArgument(actionArg) { type = NavType.StringType },
+            navArgument(baseRuleIdArg) { type = NavType.LongType },
         )
-        override val routeWithArgs = "$route/{$mutationTypeArg}"
+        override val routeWithArgs = "$route/{$mutationTypeArg}/{$actionArg}/{$baseRuleIdArg}"
+
+        /**
+         * An action that can be performed on the AddRule screen (i.e., adding a new rule or
+         * editing an existing rule).
+         */
+        enum class Action { ADD, EDIT }
     }
 }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
@@ -13,7 +13,7 @@ import com.suvanl.fixmylinks.ui.navigation.getBaseRoute
 enum class NavigationEnterTransitionMode { ENTER, POP_ENTER }
 enum class NavigationExitTransitionMode { EXIT, POP_EXIT }
 
-private val screensWithFab = listOf(FmlScreen.Home, FmlScreen.Rules)
+private val topLevelScreensWithFab = listOf(FmlScreen.Home, FmlScreen.Rules)
 
 /**
  * Returns the appropriate navigation [ExitTransition] based on the given [transitionMode] and the
@@ -30,7 +30,7 @@ fun exitNavigationTransition(
     // that has a FAB
     val isNavigatingFromFlowToTopLevelScreen =
         addNewRuleFlowScreens.any { it.route == initialDestinationRoute }
-                && screensWithFab.any { it.route == targetDestinationRoute }
+                && topLevelScreensWithFab.any { it.route == targetDestinationRoute }
 
     // If the target destination is part of the "add new rule" flow, or if we're navigating back to
     // a screen that this flow could've been started from
@@ -84,13 +84,13 @@ fun enterNavigationTransition(
     // If we're navigating from a destination with the FAB to a destination in the "add new rule"
     // flow, or if we're performing intra-flow navigation, use the slide animation
     val isNavigatingFromTopLevelDestinationToFlow =
-        screensWithFab.any { it.route == initialDestinationRoute }
+        topLevelScreensWithFab.any { it.route == initialDestinationRoute }
                 && addNewRuleFlowScreens.any { it.route == targetDestinationRoute }
 
     // Inverse of isNavigatingFromTopLevelDestinationToFlow
     val isNavigatingFromFlowToTopLevelDestination =
         addNewRuleFlowScreens.any { it.route == initialDestinationRoute }
-                && screensWithFab.any { it.route == targetDestinationRoute }
+                && topLevelScreensWithFab.any { it.route == targetDestinationRoute }
 
     return if (
         isNavigatingFromTopLevelDestinationToFlow || isNavigatingFromFlowToTopLevelDestination

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
@@ -6,14 +6,13 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.navigation.NavBackStackEntry
-import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.navigation.addNewRuleFlowScreens
 import com.suvanl.fixmylinks.ui.navigation.getBaseRoute
+import com.suvanl.fixmylinks.ui.util.topLevelScreensWithFab
 
 enum class NavigationEnterTransitionMode { ENTER, POP_ENTER }
 enum class NavigationExitTransitionMode { EXIT, POP_EXIT }
 
-private val topLevelScreensWithFab = listOf(FmlScreen.Home, FmlScreen.Rules)
 
 /**
  * Returns the appropriate navigation [ExitTransition] based on the given [transitionMode] and the

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.ui.components.button.AddNewRuleFab
 import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationBar
 import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationRail
@@ -120,9 +121,31 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
                         }
                     )
                 } else if (shouldShowEditRuleFab) {
-                    EditFab(
-                        onClick = { /*TODO*/ }
-                    )
+                    if (currentDestination != null
+                        && currentDestination.route == FmlScreen.RuleDetails.routeWithArgs) {
+                        val mutationTypeArg =
+                            navBackStackEntry?.arguments?.getString(FmlScreen.RuleDetails.mutationTypeArg)
+
+                        val mutationType = MutationType.entries.find { it.name == mutationTypeArg }
+                            ?: MutationType.FALLBACK
+
+                        val baseRuleId =
+                            navBackStackEntry?.arguments?.getLong(FmlScreen.RuleDetails.baseRuleIdArg)
+                                ?: throw NullPointerException("Expected base_rule_id to be non-null")
+
+                        fun handleEditFabClick() {
+                            val editActionRoute =
+                                "${FmlScreen.AddRule.route}/${mutationType.name}/${FmlScreen.AddRule.Action.EDIT}/$baseRuleId"
+
+                            navController.navigateSingleTop(
+                                route = editActionRoute,
+                                popUpToStartDestination = false
+                            )
+                        }
+
+                        EditFab(onClick = { handleEditFabClick() })
+                    }
+
                 }
             },
             contentWindowInsets = WindowInsets(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -61,8 +61,8 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
     // The screens on which the Floating Action Button (FAB) should be displayed
     val displayFabOn = listOf(FmlScreen.Home, FmlScreen.Rules)
 
-    // The screens on which the Navigation Bar should be hidden
-    val hideNavBarOn = listOf(FmlScreen.SelectRuleType, FmlScreen.AddRule)
+    // The screens on which the Navigation Bar should be shown
+    val showNavBarOn = listOf(FmlScreen.Home, FmlScreen.Rules, FmlScreen.Saved)
 
     val topAppBarSize = when (windowSize.widthSizeClass) {
         WindowWidthSizeClass.Compact -> TopAppBarSize.LARGE
@@ -78,14 +78,14 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
         WindowWidthSizeClass.Medium -> true
         WindowWidthSizeClass.Expanded -> true
         else -> false
-    } && hideNavBarOn.none { it.route == currentBaseRoute }
+    } && showNavBarOn.any { it.route == currentBaseRoute }
 
     val shouldShowNavBar = when (windowSize.widthSizeClass) {
         WindowWidthSizeClass.Compact -> true
         else -> false
-    } && hideNavBarOn.none { it.route == currentBaseRoute }
+    } && showNavBarOn.any { it.route == currentBaseRoute }
 
-    val shouldShowTopAppBar = hideNavBarOn.any { it.route == currentBaseRoute }
+    val shouldShowTopAppBar = showNavBarOn.none { it.route == currentBaseRoute }
     val shouldShowFab = displayFabOn.any { it.route == currentBaseRoute }
 
     FixMyLinksTheme {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -35,18 +35,15 @@ import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationBar
 import com.suvanl.fixmylinks.ui.components.nav.FmlNavigationRail
 import com.suvanl.fixmylinks.ui.components.appbar.FmlTopAppBar
 import com.suvanl.fixmylinks.ui.components.appbar.TopAppBarSize
+import com.suvanl.fixmylinks.ui.components.button.EditFab
 import com.suvanl.fixmylinks.ui.navigation.FmlNavHost
 import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.navigation.allFmlScreens
 import com.suvanl.fixmylinks.ui.navigation.getBaseRoute
 import com.suvanl.fixmylinks.ui.navigation.navigateSingleTop
 import com.suvanl.fixmylinks.ui.theme.FixMyLinksTheme
-
-private val topLevelNavItems = listOf(
-    FmlScreen.Home,
-    FmlScreen.Rules,
-    FmlScreen.Saved,
-)
+import com.suvanl.fixmylinks.ui.util.topLevelScreens
+import com.suvanl.fixmylinks.ui.util.topLevelScreensWithFab
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -57,9 +54,6 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
     val currentDestination = navBackStackEntry?.destination
     val currentBaseRoute = getBaseRoute(currentDestination?.route)
     val currentScreen = allFmlScreens.find { currentBaseRoute == it.route }
-
-    // The screens on which the Floating Action Button (FAB) should be displayed
-    val displayFabOn = listOf(FmlScreen.Home, FmlScreen.Rules)
 
     // The screens on which the Navigation Bar should be shown
     val showNavBarOn = listOf(FmlScreen.Home, FmlScreen.Rules, FmlScreen.Saved)
@@ -86,7 +80,8 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
     } && showNavBarOn.any { it.route == currentBaseRoute }
 
     val shouldShowTopAppBar = showNavBarOn.none { it.route == currentBaseRoute }
-    val shouldShowFab = displayFabOn.any { it.route == currentBaseRoute }
+    val shouldShowAddNewRuleFab = topLevelScreensWithFab.any { it.route == currentBaseRoute }
+    val shouldShowEditRuleFab = currentBaseRoute.startsWith(FmlScreen.RuleDetails.route)
 
     FixMyLinksTheme {
         Scaffold(
@@ -104,7 +99,7 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
             bottomBar = {
                 if (shouldShowNavBar) {
                     FmlNavigationBar(
-                        navItems = topLevelNavItems,
+                        navItems = topLevelScreens,
                         onNavItemClick = { screen ->
                             navController.navigateSingleTop(screen.route)
                         },
@@ -115,13 +110,19 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
             floatingActionButton = {
                 // Don't show the FAB if shouldShowNavRail is true as the navigation rail will contain
                 // a FAB within it
-                if (!shouldShowNavRail && shouldShowFab) {
-                    AddNewRuleFab(onClick = {
-                        navController.navigateSingleTop(
-                            route = FmlScreen.SelectRuleType.route,
-                            popUpToStartDestination = false
-                        )
-                    })
+                if (!shouldShowNavRail && shouldShowAddNewRuleFab) {
+                    AddNewRuleFab(
+                        onClick = {
+                            navController.navigateSingleTop(
+                                route = FmlScreen.SelectRuleType.route,
+                                popUpToStartDestination = false
+                            )
+                        }
+                    )
+                } else if (shouldShowEditRuleFab) {
+                    EditFab(
+                        onClick = { /*TODO*/ }
+                    )
                 }
             },
             contentWindowInsets = WindowInsets(
@@ -155,7 +156,7 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
                         )
                     ) {
                         FmlNavigationRail(
-                            navItems = topLevelNavItems,
+                            navItems = topLevelScreens,
                             currentDestination = currentDestination,
                             onFabClick = {
                                 navController.navigateSingleTop(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
@@ -3,6 +3,7 @@ package com.suvanl.fixmylinks.ui.screens
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -22,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndAllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
@@ -35,6 +37,7 @@ data class RulesScreenUiState(
 
 @Composable
 fun RulesScreen(
+    onClickRuleItem: (MutationType, Long) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: RulesViewModel = hiltViewModel()
 ) {
@@ -43,6 +46,9 @@ fun RulesScreen(
 
     RulesScreenBody(
         uiState = uiState,
+        onClickItem = { mutationType, baseRuleId ->
+            onClickRuleItem(mutationType, baseRuleId)
+        },
         onClickDeleteAll = {
             coroutineScope.launch {
                 viewModel.deleteAll()
@@ -60,6 +66,7 @@ fun RulesScreen(
 @Composable
 private fun RulesScreenBody(
     uiState: RulesScreenUiState,
+    onClickItem: (MutationType, Long) -> Unit,
     onClickDeleteAll: () -> Unit,
     onClickDeleteRule: (Long) -> Unit,
     modifier: Modifier = Modifier
@@ -96,8 +103,17 @@ private fun RulesScreenBody(
                         style = MaterialTheme.typography.labelMedium
                     )
 
-                    FilledTonalButton(onClick = { onClickDeleteRule(rule.baseRuleId) }) {
-                        Text(text = "Delete this")
+                    Row(horizontalArrangement = Arrangement.SpaceBetween) {
+                        FilledTonalButton(onClick = { onClickDeleteRule(rule.baseRuleId) }) {
+                            Text(text = "Delete this")
+                        }
+                        FilledTonalButton(
+                            onClick = {
+                                onClickItem(rule.mutationType, rule.baseRuleId)
+                            }
+                        ) {
+                            Text(text = "View this")
+                        }
                     }
 
                     Spacer(modifier = Modifier.height(16.dp))
@@ -135,6 +151,7 @@ private fun RulesScreenPreview() {
                     )
                 )
             ),
+            onClickItem = { _, _ -> /* do nothing */ },
             onClickDeleteAll = {},
             onClickDeleteRule = {},
         )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -1,0 +1,42 @@
+package com.suvanl.fixmylinks.ui.screens.details
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.viewmodel.rule.RuleDetailsViewModel
+
+@Composable
+fun RuleDetailsScreen(
+    mutationType: MutationType,
+    baseRuleId: Long,
+    onClickEdit: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: RuleDetailsViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(Unit) {
+        viewModel.updateSelectedRule(baseRuleId, mutationType)
+    }
+
+    val rule by viewModel.selectedRule.collectAsStateWithLifecycle()
+
+    Column(
+        modifier = modifier
+    ) {
+        Text(text = "Rule details")
+        Text(text = "type: $mutationType")
+        Text(text = "base rule ID: $baseRuleId")
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(text = "Name: ${rule?.name}; On: ${rule?.triggerDomain}")
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -44,6 +45,7 @@ import com.suvanl.fixmylinks.ui.components.form.SpecificUrlParamsRuleFormState
 import com.suvanl.fixmylinks.ui.components.form.common.ParameterNameField
 import com.suvanl.fixmylinks.ui.components.list.SwitchList
 import com.suvanl.fixmylinks.ui.components.list.SwitchListItemState
+import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 import com.suvanl.fixmylinks.viewmodel.newruleflow.AddAllUrlParamsRuleViewModel
@@ -60,9 +62,11 @@ data class AddRuleScreenUiState(
 @Composable
 fun AddRuleScreen(
     uiState: AddRuleScreenUiState,
-    viewModel: AddRuleViewModel?,
+    viewModel: AddRuleViewModel,
     onSaveClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    action: FmlScreen.AddRule.Action = FmlScreen.AddRule.Action.ADD,
+    baseRuleId: Long = 0,
 ) {
     var isRuleEnabled by rememberSaveable { mutableStateOf(true) }
     var isBackupEnabled by rememberSaveable { mutableStateOf(false) }
@@ -91,6 +95,11 @@ fun AddRuleScreen(
         onSaveClick = onSaveClick,
         modifier = modifier
     ) {
+        LaunchedEffect(action, baseRuleId) {
+            if (action != FmlScreen.AddRule.Action.EDIT || baseRuleId == 0L) return@LaunchedEffect
+            viewModel.setInitialFormUiState(uiState.mutationType, baseRuleId)
+        }
+
         when (viewModel) {
             is AddDomainNameRuleViewModel -> {
                 if (uiState.mutationType == MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL) {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/UiConstants.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/UiConstants.kt
@@ -1,0 +1,14 @@
+package com.suvanl.fixmylinks.ui.util
+
+import com.suvanl.fixmylinks.ui.navigation.FmlScreen
+
+val topLevelScreens = listOf(
+    FmlScreen.Home,
+    FmlScreen.Rules,
+    FmlScreen.Saved,
+)
+
+val topLevelScreensWithFab = listOf(
+    FmlScreen.Home,
+    FmlScreen.Rules,
+)

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/ViewModelComposableUtil.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/ViewModelComposableUtil.kt
@@ -9,7 +9,7 @@ import com.suvanl.fixmylinks.viewmodel.newruleflow.AddRuleViewModel
 import com.suvanl.fixmylinks.viewmodel.newruleflow.AddSpecificUrlParamsRuleViewModel
 
 /**
- * Returns the viewModel composable associated with the given MutationType
+ * Returns the [hiltViewModel] composable associated with the given MutationType
  */
 @Composable
 fun getNewRuleFlowViewModel(mutationType: MutationType): AddRuleViewModel {

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
@@ -55,8 +55,16 @@ class AddAllUrlParamsRuleViewModel @Inject constructor(
         )
     }
 
-    override suspend fun updateExistingRule() {
-        TODO("Not yet implemented")
+    override suspend fun updateExistingRule(baseRuleId: Long) {
+        if (!validateData()) return
+
+        val newData = AllUrlParamsMutationModel(
+            name = _formUiState.value.ruleName,
+            triggerDomain = _formUiState.value.domainName,
+            isLocalOnly = true,
+            baseRuleId = baseRuleId
+        )
+        rulesRepository.get().updateRule(baseRuleId, newData)
     }
 
     override fun validateData(): Boolean {

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
@@ -55,6 +55,10 @@ class AddAllUrlParamsRuleViewModel @Inject constructor(
         )
     }
 
+    override suspend fun updateExistingRule() {
+        TODO("Not yet implemented")
+    }
+
     override fun validateData(): Boolean {
         val domainNameValidationResult = validateDomainNameUseCase(_formUiState.value.domainName)
 

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
@@ -31,6 +31,17 @@ class AddAllUrlParamsRuleViewModel @Inject constructor(
         _formUiState.value = _formUiState.value.copy(domainName = domainName)
     }
 
+    override suspend fun setInitialFormUiState(mutationType: MutationType, baseRuleId: Long) {
+        rulesRepository.get().getRuleByBaseId(baseRuleId, mutationType).collect { rule ->
+            if (rule !is AllUrlParamsMutationModel) return@collect
+
+            _formUiState.value = AllUrlParamsRuleFormState(
+                ruleName = rule.name,
+                domainName = rule.triggerDomain,
+            )
+        }
+    }
+
     override suspend fun saveRule() {
         if (!validateData()) return
 

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
@@ -94,6 +94,11 @@ class AddDomainNameRuleViewModel @Inject constructor(
         }
     }
 
+
+    override suspend fun updateExistingRule() {
+        TODO("Not yet implemented")
+    }
+
     override fun validateData(): Boolean {
         val initialDomainNameText = _formUiState.value.initialDomainName
         val targetDomainNameText = _formUiState.value.targetDomainName

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
@@ -67,7 +67,9 @@ class AddDomainNameRuleViewModel @Inject constructor(
     override suspend fun saveRule() {
         if (!validateData()) return
 
-        if (!_removeAllUrlParams.value) {
+        val shouldRemoveAllUrlParams = _removeAllUrlParams.value
+        // "domain name" rule
+        if (!shouldRemoveAllUrlParams) {
             rulesRepository.get().saveRule(
                 DomainNameMutationModel(
                     name = _formUiState.value.ruleName,
@@ -79,24 +81,56 @@ class AddDomainNameRuleViewModel @Inject constructor(
                     )
                 )
             )
-        } else {
-            rulesRepository.get().saveRule(
-                DomainNameAndAllUrlParamsMutationModel(
-                    name = _formUiState.value.ruleName,
-                    triggerDomain = _formUiState.value.initialDomainName,
-                    isLocalOnly = true,
-                    mutationInfo = DomainNameMutationInfo(
-                        initialDomain = _formUiState.value.initialDomainName,
-                        targetDomain = _formUiState.value.targetDomainName,
-                    )
+            return
+        }
+
+        // "domain name and all url parameters" rule
+        rulesRepository.get().saveRule(
+            DomainNameAndAllUrlParamsMutationModel(
+                name = _formUiState.value.ruleName,
+                triggerDomain = _formUiState.value.initialDomainName,
+                isLocalOnly = true,
+                mutationInfo = DomainNameMutationInfo(
+                    initialDomain = _formUiState.value.initialDomainName,
+                    targetDomain = _formUiState.value.targetDomainName,
                 )
             )
-        }
+        )
     }
 
 
-    override suspend fun updateExistingRule() {
-        TODO("Not yet implemented")
+    override suspend fun updateExistingRule(baseRuleId: Long) {
+        if (!validateData()) return
+
+        val shouldRemoveAllUrlParams = _removeAllUrlParams.value
+        // "domain name" rule
+        if (!shouldRemoveAllUrlParams) {
+            val newData = DomainNameMutationModel(
+                name = _formUiState.value.ruleName,
+                triggerDomain = _formUiState.value.initialDomainName,
+                isLocalOnly = true,
+                mutationInfo = DomainNameMutationInfo(
+                    initialDomain = _formUiState.value.initialDomainName,
+                    targetDomain = _formUiState.value.targetDomainName,
+                ),
+                baseRuleId = baseRuleId
+            )
+            rulesRepository.get().updateRule(baseRuleId, newData)
+            return
+        }
+
+        // "domain name and all url parameters" rule
+        val newData = DomainNameAndAllUrlParamsMutationModel(
+            name = _formUiState.value.ruleName,
+            triggerDomain = _formUiState.value.initialDomainName,
+            isLocalOnly = true,
+            mutationInfo = DomainNameMutationInfo(
+                initialDomain = _formUiState.value.initialDomainName,
+                targetDomain = _formUiState.value.targetDomainName,
+            ),
+            baseRuleId = baseRuleId
+        )
+        rulesRepository.get().updateRule(baseRuleId, newData)
     }
 
     override fun validateData(): Boolean {

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.UserPreferences
 import com.suvanl.fixmylinks.data.repository.UserPreferencesRepository
+import com.suvanl.fixmylinks.domain.mutation.MutationType
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -21,6 +22,12 @@ abstract class AddRuleViewModel(
             started = SharingStarted.WhileSubscribed(stopTimeoutMillis = TIMEOUT_MILLIS),
             initialValue = UserPreferences()
         )
+
+    /**
+     * Sets the initial form UI state with non-default values.
+     * Use this function to prepopulate the form with data from an existing rule.
+     */
+    abstract suspend fun setInitialFormUiState(mutationType: MutationType, baseRuleId: Long)
 
     /**
      * Saves the rule locally and optionally remotely based on user preferences.

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
@@ -26,6 +26,8 @@ abstract class AddRuleViewModel(
     /**
      * Sets the initial form UI state with non-default values.
      * Use this function to prepopulate the form with data from an existing rule.
+     * @param mutationType The existing rule's [MutationType].
+     * @param baseRuleId The existing rule's base rule ID.
      */
     abstract suspend fun setInitialFormUiState(mutationType: MutationType, baseRuleId: Long)
 
@@ -33,6 +35,11 @@ abstract class AddRuleViewModel(
      * Saves the rule locally and optionally remotely based on user preferences.
      */
     abstract suspend fun saveRule()
+
+    /**
+     * Updates a rule that has already been saved (locally and remotely if applicable).
+     */
+    abstract suspend fun updateExistingRule()
 
     /**
      * Validates form data.

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
@@ -38,8 +38,9 @@ abstract class AddRuleViewModel(
 
     /**
      * Updates a rule that has already been saved (locally and remotely if applicable).
+     * @param baseRuleId The ID of the existing BaseRule entity.
      */
-    abstract suspend fun updateExistingRule()
+    abstract suspend fun updateExistingRule(baseRuleId: Long)
 
     /**
      * Validates form data.

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
@@ -79,8 +79,20 @@ class AddSpecificUrlParamsRuleViewModel @Inject constructor(
         )
     }
 
-    override suspend fun updateExistingRule() {
-        TODO("Not yet implemented")
+    override suspend fun updateExistingRule(baseRuleId: Long) {
+        if (!validateData()) return
+
+        val newData = SpecificUrlParamsMutationModel(
+            name = _formUiState.value.ruleName,
+            triggerDomain = _formUiState.value.domainName,
+            isLocalOnly = true,
+            baseRuleId = baseRuleId,
+            mutationInfo = SpecificUrlParamsMutationInfo(
+                removableParams = _formUiState.value.addedParamNames
+            )
+        )
+
+        rulesRepository.get().updateRule(baseRuleId, newData)
     }
 
     fun validateUrlParamKey(key: String): Boolean {

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
@@ -3,6 +3,7 @@ package com.suvanl.fixmylinks.viewmodel.newruleflow
 import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
 import com.suvanl.fixmylinks.data.repository.UserPreferences
+import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationInfo
 import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
@@ -49,6 +50,18 @@ class AddSpecificUrlParamsRuleViewModel @Inject constructor(
         updatedParamList.removeAt(index)
 
         _formUiState.value = _formUiState.value.copy(addedParamNames = updatedParamList)
+    }
+
+    override suspend fun setInitialFormUiState(mutationType: MutationType, baseRuleId: Long) {
+        rulesRepository.get().getRuleByBaseId(baseRuleId, mutationType).collect { rule ->
+            if (rule !is SpecificUrlParamsMutationModel) return@collect
+
+            _formUiState.value = SpecificUrlParamsRuleFormState(
+                ruleName = rule.name,
+                domainName = rule.triggerDomain,
+                addedParamNames = rule.mutationInfo.removableParams,
+            )
+        }
     }
 
     override suspend fun saveRule() {

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
@@ -79,6 +79,10 @@ class AddSpecificUrlParamsRuleViewModel @Inject constructor(
         )
     }
 
+    override suspend fun updateExistingRule() {
+        TODO("Not yet implemented")
+    }
+
     fun validateUrlParamKey(key: String): Boolean {
         val urlParamKeyResult = validateUrlParamKeyUseCase(key)
 

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/rule/RuleDetailsViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/rule/RuleDetailsViewModel.kt
@@ -1,0 +1,25 @@
+package com.suvanl.fixmylinks.viewmodel.rule
+
+import androidx.lifecycle.ViewModel
+import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class RuleDetailsViewModel @Inject constructor(
+    private val rulesRepository: RulesRepository,
+) : ViewModel() {
+
+    private val _selectedRule = MutableStateFlow<BaseMutationModel?>(null)
+    val selectedRule = _selectedRule.asStateFlow()
+
+    suspend fun updateSelectedRule(baseRuleId: Long, mutationType: MutationType) {
+        rulesRepository.getRuleByBaseId(baseRuleId, mutationType).collect { rule ->
+            _selectedRule.value = rule
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -56,4 +56,5 @@
     <string name="invalid_parameter_name">That doesn\'t look like a valid URL parameter name</string>
     <string name="add_at_least_one_param_name">Add at least one URL parameter name</string>
     <string name="rule_details">Rule details</string>
+    <string name="edit">Edit</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,4 +55,5 @@
     <string name="parameter_name_blank_error">Parameter name can\'t be blank</string>
     <string name="invalid_parameter_name">That doesn\'t look like a valid URL parameter name</string>
     <string name="add_at_least_one_param_name">Add at least one URL parameter name</string>
+    <string name="rule_details">Rule details</string>
 </resources>

--- a/app/src/test/java/com/suvanl/fixmylinks/data/repository/FakeRulesRepository.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/data/repository/FakeRulesRepository.kt
@@ -1,9 +1,18 @@
 package com.suvanl.fixmylinks.data.repository
 
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndAllUrlParamsMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationInfo
+import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 
 class FakeRulesRepository : RulesRepository {
@@ -13,6 +22,18 @@ class FakeRulesRepository : RulesRepository {
 
     override suspend fun saveRule(rule: BaseMutationModel) {
         customRules += rule
+        refreshFlow()
+    }
+
+    override suspend fun updateRule(baseRuleId: Long, newData: BaseMutationModel) {
+        val ruleIndex = customRulesStream.first().indexOfFirst { it.baseRuleId == baseRuleId }
+        if (ruleIndex == -1) {
+            throw IllegalArgumentException("Couldn't find a rule with baseRuleId $baseRuleId")
+        }
+
+        customRules.removeAt(ruleIndex)
+        customRules.add(ruleIndex, newData)
+
         refreshFlow()
     }
 
@@ -29,6 +50,18 @@ class FakeRulesRepository : RulesRepository {
         refreshFlow()
     }
 
+    override fun getRuleByBaseId(
+        baseRuleId: Long,
+        ruleType: MutationType
+    ): Flow<BaseMutationModel> {
+        runBlocking { refreshFlow() }
+
+        return customRulesStream.map { rules ->
+            rules.find { it.baseRuleId == baseRuleId && it.mutationType == ruleType }
+                ?: throw NullPointerException("Couldn't find a rule with baseRuleId $baseRuleId or mutationType $ruleType")
+        }
+    }
+
     override fun getAllRules(): Flow<List<BaseMutationModel>> {
         runBlocking {
             refreshFlow()
@@ -37,7 +70,67 @@ class FakeRulesRepository : RulesRepository {
         return customRulesStream
     }
 
+    suspend fun insertFakeData() {
+        fakeRules.forEach {
+            saveRule(it)
+        }
+
+        refreshFlow()
+    }
+
     private suspend fun refreshFlow() {
         customRulesStream = flow { emit(customRules) }
+    }
+
+    companion object {
+        private val fakeRules = listOf(
+            AllUrlParamsMutationModel(
+                baseRuleId = 1,
+                name = "My rule",
+                triggerDomain = "instagram.com",
+                isLocalOnly = true,
+            ),
+            AllUrlParamsMutationModel(
+                baseRuleId = 2,
+                name = "My second rule",
+                triggerDomain = "spotify.com",
+                isLocalOnly = true,
+            ),
+            DomainNameMutationModel(
+                baseRuleId = 3,
+                name = "twitter to x",
+                triggerDomain = "x.com",
+                isLocalOnly = true,
+                mutationInfo = DomainNameMutationInfo(
+                    initialDomain = "twitter.com",
+                    targetDomain = "x.com",
+                ),
+            ),
+            AllUrlParamsMutationModel(
+                baseRuleId = 4,
+                name = "My second rule",
+                triggerDomain = "spotify.com",
+                isLocalOnly = true,
+            ),
+            DomainNameAndAllUrlParamsMutationModel(
+                baseRuleId = 5,
+                name = "Android Dev",
+                triggerDomain = "developer.android.com",
+                isLocalOnly = true,
+                mutationInfo = DomainNameMutationInfo(
+                    initialDomain = "developer.android.com",
+                    targetDomain = "d.android.com",
+                ),
+            ),
+            SpecificUrlParamsMutationModel(
+                baseRuleId = 6,
+                name = "YouTube - remove playlist association",
+                triggerDomain = "youtube.com",
+                isLocalOnly = true,
+                mutationInfo = SpecificUrlParamsMutationInfo(
+                    removableParams = listOf("list"),
+                ),
+            ),
+        )
     }
 }

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
@@ -212,4 +212,28 @@ class MutateUriUseCaseTest {
 
         assertEquals(expected, actual)
     }
+
+    @Test
+    fun `no rule - link containing 'www' subdomain and no URL params doesn't modify original link`() {
+        val actual = mutateUriUseCase(
+            URI("https://www.framer.com/motion/guide-reduce-bundle-size/"),
+            mockCustomRules
+        )
+        // URI should not change
+        val expected = URI("https://www.framer.com/motion/guide-reduce-bundle-size/")
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `built-in rule - link containing 'www' subdomain and no URL params doesn't modify original link`() {
+        val actual = mutateUriUseCase(
+            URI("https://www.open.spotify.com/track/3PRljkcobGtC6Kc3ILLSmq"),
+            mockCustomRules
+        )
+        // URI should not change
+        val expected = URI("https://www.open.spotify.com/track/3PRljkcobGtC6Kc3ILLSmq")
+
+        assertEquals(expected, actual)
+    }
 }

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModelTest.kt
@@ -5,12 +5,18 @@ import com.suvanl.fixmylinks.data.repository.FakeRulesRepository
 import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
 import com.suvanl.fixmylinks.data.repository.UserPreferences
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
+import com.suvanl.fixmylinks.ui.components.form.AllUrlParamsRuleFormState
 import com.suvanl.fixmylinks.viewmodel.newruleflow.util.FakeDomainNameValidator
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -67,6 +73,52 @@ class AddAllUrlParamsRuleViewModelTest {
             // Assert that the rule hasn't been saved in the data source
             val rule = allRules.find { it.name == ruleName }
             assertNull(rule)
+        }
+    }
+
+    @Test
+    fun `updating an existing rule results in it being replaced with new data`() {
+        val baseRuleId = 2L
+        val formUiState = AllUrlParamsRuleFormState(
+            ruleName = "My Spotify rule",
+            domainName = "www.spotify.com",
+        )
+
+        val newData = AllUrlParamsMutationModel(
+            baseRuleId = baseRuleId,
+            name = formUiState.ruleName,
+            triggerDomain = formUiState.domainName,
+            isLocalOnly = true,
+        )
+
+        runBlocking {
+            (rulesRepository as FakeRulesRepository).insertFakeData()
+            rulesRepository.updateRule(baseRuleId, newData)
+
+            // verify update
+            val updated = rulesRepository.getRuleByBaseId(baseRuleId, MutationType.URL_PARAMS_ALL).first()
+            assertTrue(updated is AllUrlParamsMutationModel)
+            assertEquals(newData, updated)
+        }
+    }
+
+    @Test
+    fun `updating a rule that doesn't exist throws an exception`() {
+        val baseRuleId = 20L
+        val formUiState = AllUrlParamsRuleFormState()
+        val newData = AllUrlParamsMutationModel(
+            baseRuleId = baseRuleId,
+            name = formUiState.ruleName,
+            triggerDomain = formUiState.domainName,
+            isLocalOnly = true,
+        )
+
+        // should throw an IAE if a rule with the given baseRuleId can't be found in the data source
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                (rulesRepository as FakeRulesRepository).insertFakeData()
+                rulesRepository.updateRule(baseRuleId, newData)
+            }
         }
     }
 

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModelTest.kt
@@ -5,12 +5,19 @@ import com.suvanl.fixmylinks.data.repository.FakeRulesRepository
 import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.RulesRepository
 import com.suvanl.fixmylinks.data.repository.UserPreferences
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationModel
 import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
+import com.suvanl.fixmylinks.ui.components.form.DomainNameRuleFormState
 import com.suvanl.fixmylinks.viewmodel.newruleflow.util.FakeDomainNameValidator
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -53,6 +60,58 @@ class AddDomainNameRuleViewModelTest {
             // Assert that the rule exists in the data source
             val rule = allRules.find { it.name == ruleName && it.triggerDomain == initialDomainName }
             assertNotNull(rule)
+        }
+    }
+
+    @Test
+    fun `updating an existing rule results in it being replaced with new data`() {
+        val baseRuleId = 3L
+        val formUiState = DomainNameRuleFormState(
+            ruleName = "x to twitter",
+            initialDomainName = "x.com",
+            targetDomainName = "www.twitter.com",
+        )
+        val newData = DomainNameMutationModel(
+            baseRuleId = baseRuleId,
+            name = formUiState.ruleName,
+            triggerDomain = formUiState.initialDomainName,
+            isLocalOnly = true,
+            mutationInfo = DomainNameMutationInfo(
+                initialDomain = formUiState.initialDomainName,
+                targetDomain = formUiState.targetDomainName,
+            ),
+        )
+
+        runBlocking {
+            (rulesRepository as FakeRulesRepository).insertFakeData()
+            rulesRepository.updateRule(baseRuleId, newData)
+
+            val updated = rulesRepository.getRuleByBaseId(baseRuleId, MutationType.DOMAIN_NAME).first()
+            assertTrue(updated is DomainNameMutationModel)
+            assertEquals(newData, updated)
+        }
+    }
+
+    @Test
+    fun `updating a rule that doesn't exist throws an exception`() {
+        val baseRuleId = 12L
+        val formUiState = DomainNameRuleFormState()
+        val newData = DomainNameMutationModel(
+            baseRuleId = baseRuleId,
+            name = formUiState.ruleName,
+            triggerDomain = formUiState.initialDomainName,
+            isLocalOnly = true,
+            mutationInfo = DomainNameMutationInfo(
+                initialDomain = formUiState.initialDomainName,
+                targetDomain = formUiState.targetDomainName,
+            ),
+        )
+
+        assertThrows(IllegalArgumentException::class.java) {
+            runBlocking {
+                (rulesRepository as FakeRulesRepository).insertFakeData()
+                rulesRepository.updateRule(baseRuleId, newData)
+            }
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.2" apply false
+    id("com.android.application") version "8.1.4" apply false
     id("org.jetbrains.kotlin.android") version "1.9.20" apply false
     id("com.guardsquare.appsweep") version "latest.release" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.4" apply false
+    id("com.android.application") version "8.2.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.20" apply false
     id("com.guardsquare.appsweep") version "latest.release" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Sep 13 17:03:15 BST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

It currently isn't possible to edit/update existing custom rules; they can only be created, read, and deleted.

This PR adds the ability to edit/update rules, ensuring that the locally stored record gets updated.
Editing a rule uses the same form as creating a rule, but with fields prepopulated with data from the existing rule.


## 🧑‍💻 Implementation / changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
- Implemented the ability to get a specific rule from its BaseRule `id`.
- Created **RuleDetailsScreen** for viewing details of a specific rule.
  -  Contains an "Edit" FAB which navigates to AddRuleScreen but with form fields prepopulated with data from the existing rule.
  - Data is passed between screens using navigation arguments containing the BaseRule `id` and the `MutationType` of the rule.
- `FmlScreen.AddRule` also takes an "action" navigation argument, which is a string representation of the `Action` enum, which has constants `ADD` and `EDIT`. Based on the value of this argument (as well as whether the "base_rule_id" argument has a non-zero value or not), the form within AddRuleScreen will be empty or prepopulated. This also determines which ViewModel function is called - either `saveRule()` or `updateExistingRule()`.
- Added an `updateRule` function to RulesRepository and implemented it in CustomRulesRepository.
  - Updates the locally stored rule and will, in future, update the remotely stored equivalent (if applicable)
- Added an overload to `<domain model>.toDatabaseEntity()` to explicitly provide the `id` (primary key) of the specific (non-base) rule, as Room checks this when executing a DAO function annotated with `@Update`.


## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
### Manual testing
- Manually tested the user flow with the following user intents:
  - creating a rule
  - editing a rule

### Unit testing
- Added ViewModel unit tests to verify that:
  - editing an existing rule successfully updates the data source (via the RulesRepository implementation)
  - an exception is thrown if attempting to update a rule that doesn't already exist.


## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A