### PR TITLE
✨ Display general rule details on RuleDetailsScreen and enable multi-selection of rules on RulesScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,7 +64,7 @@ android {
 
 dependencies {
     val lifecycleVersion = "2.6.2"
-    val navVersion = "2.7.5"
+    val navVersion = "2.7.6"
     val roomVersion = "2.6.1"
     val daggerHiltVersion = "2.48.1"
     val androidxHiltVersion = "1.1.0"
@@ -75,7 +75,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:$lifecycleVersion")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycleVersion")
     implementation("androidx.navigation:navigation-compose:$navVersion")
-    implementation("androidx.activity:activity-compose:1.8.1")
+    implementation("androidx.activity:activity-compose:1.8.2")
     implementation("androidx.graphics:graphics-shapes:1.0.0-alpha03")
 
     implementation("androidx.room:room-runtime:$roomVersion")
@@ -92,7 +92,7 @@ dependencies {
     implementation("androidx.compose.material3:material3-window-size-class")
     implementation("androidx.compose.material:material-icons-extended")
 
-    implementation("com.google.android.material:material:1.10.0")
+    implementation("com.google.android.material:material:1.11.0")
 
     implementation("com.google.dagger:dagger:$daggerHiltVersion")
     ksp("com.google.dagger:dagger-compiler:$daggerHiltVersion")

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/navigation/NavigationTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/navigation/NavigationTest.kt
@@ -5,9 +5,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.suvanl.fixmylinks.viewmodel.FakeAppLevelViewModel
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -31,7 +33,8 @@ class NavigationTest {
 
             FmlNavHost(
                 navController = navController,
-                windowWidthSize = WindowWidthSizeClass.Compact
+                windowWidthSize = WindowWidthSizeClass.Compact,
+                mainViewModel = viewModel<FakeAppLevelViewModel>()
             )
         }
     }

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/AddRuleScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/AddRuleScreenTest.kt
@@ -1,17 +1,12 @@
 package com.suvanl.fixmylinks.ui.screens
 
 import androidx.activity.ComponentActivity
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Backup
-import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.ui.components.form.AllUrlParamsRuleForm
 import com.suvanl.fixmylinks.ui.components.form.AllUrlParamsRuleFormState
@@ -19,7 +14,6 @@ import com.suvanl.fixmylinks.ui.components.form.DomainNameRuleForm
 import com.suvanl.fixmylinks.ui.components.form.DomainNameRuleFormState
 import com.suvanl.fixmylinks.ui.components.form.SpecificUrlParamsRuleForm
 import com.suvanl.fixmylinks.ui.components.form.SpecificUrlParamsRuleFormState
-import com.suvanl.fixmylinks.ui.components.list.SwitchListItemState
 import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreenBody
 import org.junit.Rule
 import org.junit.Test
@@ -36,27 +30,9 @@ class AddRuleScreenTest {
         mutationType: MutationType,
         layoutClass: String = "Compact",
     ) {
-        val ruleOptions = listOf(
-            SwitchListItemState(
-                headlineText = stringResource(id = R.string.enable),
-                supportingText = stringResource(R.string.enable_rule_supporting_text),
-                leadingIcon = Icons.Outlined.CheckCircle,
-                isSwitchChecked = true,
-                onSwitchCheckedChange = {},
-            ),
-            SwitchListItemState(
-                headlineText = stringResource(R.string.backup_to_cloud),
-                supportingText = stringResource(R.string.backup_to_cloud_supporting_text),
-                leadingIcon = Icons.Outlined.Backup,
-                isSwitchChecked = false,
-                onSwitchCheckedChange = {},
-            )
-        )
-
         AddRuleScreenBody(
             mutationType = mutationType,
             showSaveButton = layoutClass.lowercase() == "compact",
-            ruleOptions = ruleOptions,
             onSaveClick = {}
         ) {
             when (mutationType) {

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -63,6 +63,7 @@ class RulesScreenTest {
             RulesScreen(
                 uiState = RulesScreenUiState(),
                 onClickRuleItem = {},
+                selectedItems = setOf(),
                 onUpdateSelectedItems = {},
             )
         }
@@ -72,6 +73,7 @@ class RulesScreenTest {
             RulesScreen(
                 uiState = RulesScreenUiState(rules = fakeRules),
                 onClickRuleItem = {},
+                selectedItems = setOf(),
                 onUpdateSelectedItems = {},
             )
         }

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -63,6 +63,7 @@ class RulesScreenTest {
             RulesScreen(
                 uiState = RulesScreenUiState(),
                 onClickRuleItem = {},
+                onUpdateSelectedItems = {},
             )
         }
 
@@ -71,6 +72,7 @@ class RulesScreenTest {
             RulesScreen(
                 uiState = RulesScreenUiState(rules = fakeRules),
                 onClickRuleItem = {},
+                onUpdateSelectedItems = {},
             )
         }
 

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -46,7 +46,7 @@ class RulesScreenTest {
 
         fakeRules.forEach { rule ->
             composeTestRule
-                .onNodeWithTag("Rules List Item ${rule.baseRuleId}")
+                .onNodeWithTag("Rules List Item ${rule.baseRuleId}", useUnmergedTree = true)
                 .assertExists()
                 .assertIsDisplayed()
 

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -7,10 +7,12 @@ import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelectable
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndAllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
@@ -121,6 +123,58 @@ class RulesScreenTest {
                 .onNodeWithTag(testTag, useUnmergedTree = true)
                 .assertExists()
                 .assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun rulesScreen_correctShapeForEachRuleType_isDisplayed() {
+        composeTestRule.setContent {
+            RulesScreen(
+                uiState = RulesScreenUiState(rules = fakeRules),
+                onClickRuleItem = {},
+                selectedItems = setOf(),
+                onUpdateSelectedItems = {},
+            )
+        }
+
+        fakeRules.forEach { rule ->
+            when (rule.mutationType) {
+                MutationType.DOMAIN_NAME -> {
+                    composeTestRule.onNodeWithContentDescription("Square")
+                        .assertExists()
+                        .assertIsDisplayed()
+                }
+
+                MutationType.URL_PARAMS_ALL -> {
+                    composeTestRule.onNodeWithContentDescription("Scallop")
+                        .assertExists()
+                        .assertIsDisplayed()
+                }
+
+                MutationType.URL_PARAMS_SPECIFIC -> {
+                    composeTestRule.onNodeWithContentDescription("Delta")
+                        .assertExists()
+                        .assertIsDisplayed()
+                }
+
+                MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
+                    composeTestRule.onNodeWithContentDescription("Clover")
+                        .assertExists()
+                        .assertIsDisplayed()
+                }
+
+                MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> {
+                    composeTestRule.onNodeWithContentDescription("Eight-point star")
+                        .assertExists()
+                        .assertIsDisplayed()
+                }
+
+                MutationType.FALLBACK -> {
+                    composeTestRule.onNodeWithContentDescription("Circle")
+                        .assertExists()
+                        .assertIsDisplayed()
+                }
+            }
         }
     }
 

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
@@ -1,0 +1,195 @@
+package com.suvanl.fixmylinks.ui.screens.details
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndAllUrlParamsMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationInfo
+import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationModel
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RuleDetailsScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    // pst = present simple tense
+    private lateinit var allUrlParamsPstString: String
+    private lateinit var domainNameAndAllUrlParamsPstString: String
+    private lateinit var domainNamePstString: String
+    private lateinit var specificUrlParamsPstString: String
+
+    @Before
+    fun setup() {
+        composeTestRule.apply {
+            // Init string resources
+            allUrlParamsPstString =
+                activity.getString(R.string.mt_url_params_all_present_simple_tense)
+
+            domainNameAndAllUrlParamsPstString =
+                activity.getString(R.string.mt_domain_name_and_url_params_all_present_simple_tense)
+
+            domainNamePstString =
+                activity.getString(R.string.mt_domain_name_present_simple_tense)
+
+            specificUrlParamsPstString =
+                activity.getString(R.string.mt_url_params_specific_present_simple_tense)
+        }
+    }
+
+    @Test
+    fun ruleDetailsScreen_isDisplayed() {
+        composeTestRule.setContent {
+            RuleDetailsScreen(
+                rule = AllUrlParamsMutationModel(
+                    name = "My rule",
+                    triggerDomain = "github.com",
+                    dateModifiedTimestamp = 0,
+                    isLocalOnly = true,
+                    baseRuleId = 1
+                ),
+                showDeleteConfirmation = false,
+                onDismissDeleteConfirmation = {},
+                onDelete = {},
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("Rule Details Screen")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun ruleDetailsScreen_allUrlParamsRule_presentSimpleTenseDescription_isDisplayed() {
+        composeTestRule.setContent {
+            RuleDetailsScreen(
+                rule = AllUrlParamsMutationModel(
+                    name = "My rule",
+                    triggerDomain = "github.com",
+                    dateModifiedTimestamp = 0,
+                    isLocalOnly = true,
+                    baseRuleId = 1
+                ),
+                showDeleteConfirmation = false,
+                onDismissDeleteConfirmation = {},
+                onDelete = {},
+            )
+        }
+
+        // Assert that the wrong text is not rendered
+        composeTestRule.onNodeWithText(domainNameAndAllUrlParamsPstString).assertDoesNotExist()
+        composeTestRule.onNodeWithText(domainNamePstString).assertDoesNotExist()
+        composeTestRule.onNodeWithText(specificUrlParamsPstString).assertDoesNotExist()
+
+        // Assert that the correct text is displayed
+        composeTestRule.onNodeWithText(allUrlParamsPstString)
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun ruleDetailsScreen_domainNameAndAllUrlParamsRule_presentSimpleTenseDescription_isDisplayed() {
+        composeTestRule.setContent {
+            RuleDetailsScreen(
+                rule = DomainNameAndAllUrlParamsMutationModel(
+                    name = "My rule",
+                    triggerDomain = "google.com",
+                    dateModifiedTimestamp = 0,
+                    isLocalOnly = true,
+                    baseRuleId = 1,
+                    mutationInfo = DomainNameMutationInfo(
+                        initialDomain = "google.com",
+                        targetDomain = "google.fr",
+                    )
+                ),
+                showDeleteConfirmation = false,
+                onDismissDeleteConfirmation = {},
+                onDelete = {},
+            )
+        }
+
+        // Assert that the wrong text is not rendered
+        composeTestRule.onNodeWithText(allUrlParamsPstString).assertDoesNotExist()
+        composeTestRule.onNodeWithText(domainNamePstString).assertDoesNotExist()
+        composeTestRule.onNodeWithText(specificUrlParamsPstString).assertDoesNotExist()
+
+        // Assert that the correct text is displayed
+        composeTestRule.onNodeWithText(domainNameAndAllUrlParamsPstString)
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun ruleDetailsScreen_domainNameRule_presentSimpleTenseDescription_isDisplayed() {
+        composeTestRule.setContent {
+            RuleDetailsScreen(
+                rule = DomainNameMutationModel(
+                    name = "My rule",
+                    triggerDomain = "google.com",
+                    dateModifiedTimestamp = 0,
+                    isLocalOnly = true,
+                    baseRuleId = 1,
+                    mutationInfo = DomainNameMutationInfo(
+                        initialDomain = "google.com",
+                        targetDomain = "google.fr",
+                    )
+                ),
+                showDeleteConfirmation = false,
+                onDismissDeleteConfirmation = {},
+                onDelete = {},
+            )
+        }
+
+        // Assert that the wrong text is not rendered
+        composeTestRule.onNodeWithText(allUrlParamsPstString).assertDoesNotExist()
+        composeTestRule.onNodeWithText(domainNameAndAllUrlParamsPstString).assertDoesNotExist()
+        composeTestRule.onNodeWithText(specificUrlParamsPstString).assertDoesNotExist()
+
+        // Assert that the correct text is displayed
+        composeTestRule.onNodeWithText(domainNamePstString)
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun ruleDetailsScreen_specificUrlParamsRule_presentSimpleTenseDescription_isDisplayed() {
+        composeTestRule.setContent {
+            RuleDetailsScreen(
+                rule = SpecificUrlParamsMutationModel(
+                    name = "My rule",
+                    triggerDomain = "youtube.com",
+                    dateModifiedTimestamp = 0,
+                    isLocalOnly = true,
+                    baseRuleId = 1,
+                    mutationInfo = SpecificUrlParamsMutationInfo(
+                        removableParams = listOf("list", "t")
+                    )
+                ),
+                showDeleteConfirmation = false,
+                onDismissDeleteConfirmation = {},
+                onDelete = {},
+            )
+        }
+
+        // Assert that the wrong text is not rendered
+        composeTestRule.onNodeWithText(allUrlParamsPstString).assertDoesNotExist()
+        composeTestRule.onNodeWithText(domainNameAndAllUrlParamsPstString).assertDoesNotExist()
+        composeTestRule.onNodeWithText(domainNamePstString).assertDoesNotExist()
+
+        // Assert that the correct text is displayed
+        composeTestRule.onNodeWithText(specificUrlParamsPstString)
+            .assertExists()
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
@@ -4,10 +4,11 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
 import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndAllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationModel
@@ -30,6 +31,8 @@ class RuleDetailsScreenTest {
     private lateinit var domainNamePstString: String
     private lateinit var specificUrlParamsPstString: String
 
+    private lateinit var cancelString: String
+
     @Before
     fun setup() {
         composeTestRule.apply {
@@ -45,6 +48,8 @@ class RuleDetailsScreenTest {
 
             specificUrlParamsPstString =
                 activity.getString(R.string.mt_url_params_specific_present_simple_tense)
+
+            cancelString = activity.getString(android.R.string.cancel)
         }
     }
 
@@ -189,6 +194,31 @@ class RuleDetailsScreenTest {
 
         // Assert that the correct text is displayed
         composeTestRule.onNodeWithText(specificUrlParamsPstString)
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun ruleDetailsScreen_showDeleteConfirmation_alertDialog_isDisplayed() {
+        composeTestRule.setContent {
+            RuleDetailsScreen(
+                rule = SpecificUrlParamsMutationModel(
+                    name = "My rule",
+                    triggerDomain = "youtube.com",
+                    dateModifiedTimestamp = 0,
+                    isLocalOnly = true,
+                    baseRuleId = 1,
+                    mutationInfo = SpecificUrlParamsMutationInfo(
+                        removableParams = listOf("list", "t")
+                    )
+                ),
+                showDeleteConfirmation = true,
+                onDismissDeleteConfirmation = {},
+                onDelete = {},
+            )
+        }
+
+        composeTestRule.onNodeWithTag("Delete Confirmation Dialog")
             .assertExists()
             .assertIsDisplayed()
     }

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/viewmodel/FakeAppLevelViewModel.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/viewmodel/FakeAppLevelViewModel.kt
@@ -1,0 +1,22 @@
+package com.suvanl.fixmylinks.viewmodel
+
+import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakeAppLevelViewModel : AppLevelViewModel() {
+    override val multiSelectedRules: StateFlow<Set<BaseMutationModel>> =
+        MutableStateFlow(fakeSelectedRules)
+
+    override fun updateMultiSelectedRules(updatedSet: Set<BaseMutationModel>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun clearMultiSelectedRules() {
+        TODO("Not yet implemented")
+    }
+
+    companion object {
+        val fakeSelectedRules = mutableSetOf<BaseMutationModel>()
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/RuleSelectionTopAppBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/RuleSelectionTopAppBar.kt
@@ -13,11 +13,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.FloatingWindow
 import androidx.navigation.NavBackStackEntry
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
@@ -68,7 +70,7 @@ private fun RuleSelectionTopAppBarBody(
                 )
             }
         },
-        colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp)),
         actions = actions,
         modifier = modifier
     )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/RuleSelectionTopAppBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/RuleSelectionTopAppBar.kt
@@ -1,0 +1,105 @@
+package com.suvanl.fixmylinks.ui.components.appbar
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.SelectAll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.FloatingWindow
+import androidx.navigation.NavBackStackEntry
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNot
+
+@Composable
+fun RuleSelectionTopAppBar(
+    selectedItemsSize: Int,
+    currentBackStackEntryFlow: Flow<NavBackStackEntry>,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val currentContentBackStackEntry by produceState(
+        initialValue = null as NavBackStackEntry?,
+        producer = {
+            currentBackStackEntryFlow
+                .filterNot { it.destination is FloatingWindow }
+                .collect { value = it }
+        }
+    )
+
+    RuleSelectionTopAppBarBody(
+        selectedItemsSize = selectedItemsSize,
+        onDismiss = onDismiss,
+        actions = { AppBarActionRow(navBackStackEntry = currentContentBackStackEntry) },
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RuleSelectionTopAppBarBody(
+    selectedItemsSize: Int,
+    onDismiss: () -> Unit,
+    actions: @Composable RowScope.() -> Unit,
+    modifier: Modifier = Modifier
+) {
+    TopAppBar(
+        title = {
+            Text(text = selectedItemsSize.toString())
+        },
+        navigationIcon = {
+            IconButton(onClick = onDismiss) {
+                Icon(
+                    imageVector = Icons.Outlined.Close,
+                    contentDescription = "Clear selection"
+                )
+            }
+        },
+        colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+        actions = actions,
+        modifier = modifier
+    )
+}
+
+@Preview
+@Preview(
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun RuleSelectionTopAppBarPreview() {
+    PreviewContainer {
+        RuleSelectionTopAppBarBody(
+            selectedItemsSize = 3,
+            onDismiss = {},
+            actions = {
+                IconButton(onClick = {}) {
+                    Icon(
+                        imageVector = Icons.Outlined.Delete,
+                        contentDescription = "Delete selected"
+                    )
+                }
+
+                IconButton(onClick = {}) {
+                    Icon(
+                        imageVector = Icons.Outlined.SelectAll,
+                        contentDescription = "Select all"
+                    )
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/TopAppBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/appbar/TopAppBar.kt
@@ -48,7 +48,7 @@ fun FmlTopAppBar(
         TopAppBarSize.SMALL -> {
             TopAppBar(
                 title = { TopAppBarTitle(text = title) },
-                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = onNavigateUp) },
                 actions = { AppBarActionRow(navBackStackEntry = currentContentBackStackEntry) },
                 scrollBehavior = scrollBehavior,
                 modifier = modifier
@@ -58,7 +58,7 @@ fun FmlTopAppBar(
         TopAppBarSize.MEDIUM -> {
             MediumTopAppBar(
                 title = { TopAppBarTitle(text = title) },
-                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = onNavigateUp) },
                 actions = { AppBarActionRow(navBackStackEntry = currentContentBackStackEntry) },
                 scrollBehavior = scrollBehavior,
                 modifier = modifier
@@ -68,7 +68,7 @@ fun FmlTopAppBar(
         TopAppBarSize.LARGE -> {
             LargeTopAppBar(
                 title = { TopAppBarTitle(text = title) },
-                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = { onNavigateUp() }) },
+                navigationIcon = { TopAppBarNavigationIcon(onNavigateUp = onNavigateUp) },
                 actions = { AppBarActionRow(navBackStackEntry = currentContentBackStackEntry) },
                 scrollBehavior = scrollBehavior,
                 modifier = modifier

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RuleDetailsList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RuleDetailsList.kt
@@ -1,0 +1,120 @@
+package com.suvanl.fixmylinks.ui.components.list
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.ui.util.PreviewData
+
+@Composable
+fun RuleDetailsList(
+    details: List<RuleDetailsListItemState>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+        modifier = modifier,
+    ) {
+        itemsIndexed(details) { index, item ->
+            val shape = getItemShape(details, index)
+
+            RuleDetailsListItem(
+                state = item,
+                shape = shape,
+            )
+        }
+    }
+}
+
+private fun getItemShape(list: List<RuleDetailsListItemState>, currentIndex: Int): Shape {
+    val itemCornerRadius = 5.dp
+    val endItemCornerRadius = 32.dp
+
+    return when (currentIndex) {
+        0 -> {
+            RoundedCornerShape(
+                topStart = endItemCornerRadius,
+                topEnd = endItemCornerRadius,
+                bottomStart = itemCornerRadius,
+                bottomEnd = itemCornerRadius,
+            )
+        }
+
+        list.lastIndex -> {
+            RoundedCornerShape(
+                topStart = itemCornerRadius,
+                topEnd = itemCornerRadius,
+                bottomStart = endItemCornerRadius,
+                bottomEnd = endItemCornerRadius,
+            )
+        }
+
+        else -> {
+            RoundedCornerShape(itemCornerRadius)
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 320,
+)
+@Preview(
+    showBackground = true,
+    widthDp = 320,
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun RuleDetailsListPreview() {
+    val rules = PreviewData.previewRules
+
+    PreviewContainer {
+        Column(
+            modifier = Modifier.background(color = MaterialTheme.colorScheme.inverseOnSurface)
+        ) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            RuleDetailsList(
+                details = listOf(
+                    RuleDetailsListItemState(
+                        headlineText = rules[0].name,
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Description,
+                                contentDescription = null,
+                            )
+                        },
+                    ),
+                    RuleDetailsListItemState(
+                        headlineText = rules[0].triggerDomain,
+                        leadingIcon = {
+                            Icon(
+                                imageVector = Icons.Outlined.Search,
+                                contentDescription = null,
+                            )
+                        },
+                    ),
+                )
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RuleDetailsListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RuleDetailsListItem.kt
@@ -1,0 +1,91 @@
+package com.suvanl.fixmylinks.ui.components.list
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+data class RuleDetailsListItemState(
+    val headlineText: String,
+    val leadingIcon: @Composable () -> Unit,
+    val supportingText: String? = null,
+)
+
+@Composable
+fun RuleDetailsListItem(
+    state: RuleDetailsListItemState,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(5.dp),
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        shape = shape,
+        modifier = modifier
+    ) {
+        ListItem(
+            headlineContent = {
+                Text(text = state.headlineText, fontWeight = FontWeight.SemiBold)
+            },
+            supportingContent = {
+                if (state.supportingText != null) {
+                    Text(text = state.supportingText)
+                }
+            },
+            leadingContent = {
+                Box(
+                    modifier = Modifier
+                        .background(
+                            color = MaterialTheme.colorScheme.inverseOnSurface,
+                            shape = CircleShape
+                        )
+                        .padding(8.dp)
+                ) {
+                    state.leadingIcon()
+                }
+            },
+            colors = ListItemDefaults.colors(
+                containerColor = Color.Transparent
+            ),
+        )
+    }
+}
+
+@Preview
+@Preview(
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun RuleDetailsListItemPreview() {
+    PreviewContainer {
+        RuleDetailsListItem(
+            state = RuleDetailsListItemState(
+                headlineText = "Change X.com to Twitter.com",
+                leadingIcon = {
+                    Icon(imageVector = Icons.Outlined.Description, contentDescription = null)
+                },
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.selectableGroup
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
@@ -38,7 +40,7 @@ fun RulesList(
 
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = modifier
+        modifier = modifier.semantics { selectableGroup() }
     ) {
         items(items = items) { rule ->
             RulesListItem(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -9,10 +9,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -26,17 +22,18 @@ import com.suvanl.fixmylinks.ui.util.PreviewData
 fun RulesList(
     uiState: RulesScreenUiState,
     onClickItem: (BaseMutationModel) -> Unit,
+    selectedItems: Set<BaseMutationModel>,
     onUpdateSelectedItems: (Set<BaseMutationModel>) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val items = uiState.rules.sortedByDescending { it.dateModifiedTimestamp }
 
-    // TODO: hoist this state higher?
-    var selectedRules by remember { mutableStateOf(setOf<BaseMutationModel>()) }
-
     fun toggleItemSelection(rule: BaseMutationModel) {
-        if (selectedRules.contains(rule)) selectedRules -= rule else selectedRules += rule
-        onUpdateSelectedItems(selectedRules)
+        if (selectedItems.contains(rule)) {
+            onUpdateSelectedItems(selectedItems - rule)
+        } else {
+            onUpdateSelectedItems(selectedItems + rule)
+        }
     }
 
     LazyColumn(
@@ -46,11 +43,11 @@ fun RulesList(
         items(items = items) { rule ->
             RulesListItem(
                 rule = rule,
-                isSelected = selectedRules.contains(rule),
+                isSelected = selectedItems.contains(rule),
                 modifier = Modifier
                     .combinedClickable(
                         onClick = {
-                            val isInSelectionMode = selectedRules.isNotEmpty()
+                            val isInSelectionMode = selectedItems.isNotEmpty()
                             if (isInSelectionMode) toggleItemSelection(rule) else onClickItem(rule)
                         },
                         onLongClick = { toggleItemSelection(rule) }
@@ -80,6 +77,7 @@ private fun RulesListPreview() {
         RulesList(
             uiState = RulesScreenUiState(rules = PreviewData.previewRules),
             onClickItem = {},
+            selectedItems = setOf(),
             onUpdateSelectedItems = {},
         )
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -1,12 +1,18 @@
 package com.suvanl.fixmylinks.ui.components.list
 
 import android.content.res.Configuration
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -15,13 +21,23 @@ import com.suvanl.fixmylinks.ui.screens.RulesScreenUiState
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 import com.suvanl.fixmylinks.ui.util.PreviewData
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RulesList(
     uiState: RulesScreenUiState,
     onClickItem: (BaseMutationModel) -> Unit,
+    onUpdateSelectedItems: (Set<BaseMutationModel>) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val items = uiState.rules.sortedByDescending { it.dateModifiedTimestamp }
+
+    // TODO: hoist this state higher?
+    var selectedRules by remember { mutableStateOf(setOf<BaseMutationModel>()) }
+
+    fun toggleItemSelection(rule: BaseMutationModel) {
+        if (selectedRules.contains(rule)) selectedRules -= rule else selectedRules += rule
+        onUpdateSelectedItems(selectedRules)
+    }
 
     LazyColumn(
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -30,7 +46,15 @@ fun RulesList(
         items(items = items) { rule ->
             RulesListItem(
                 rule = rule,
-                onClick = { onClickItem(it) }
+                isSelected = selectedRules.contains(rule),
+                modifier = Modifier
+                    .combinedClickable(
+                        onClick = {
+                            val isInSelectionMode = selectedRules.isNotEmpty()
+                            if (isInSelectionMode) toggleItemSelection(rule) else onClickItem(rule)
+                        },
+                        onLongClick = { toggleItemSelection(rule) }
+                    )
             )
         }
 
@@ -55,7 +79,8 @@ private fun RulesListPreview() {
     PreviewContainer {
         RulesList(
             uiState = RulesScreenUiState(rules = PreviewData.previewRules),
-            onClickItem = { /* do nothing */ }
+            onClickItem = {},
+            onUpdateSelectedItems = {},
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
@@ -1,7 +1,6 @@
 package com.suvanl.fixmylinks.ui.components.list
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -31,12 +30,16 @@ import com.suvanl.fixmylinks.ui.util.getShapeForRule
 @Composable
 fun RulesListItem(
     rule: BaseMutationModel,
-    onClick: (BaseMutationModel) -> Unit,
+    isSelected: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Card(
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = if (!isSelected) {
+                MaterialTheme.colorScheme.surfaceVariant
+            } else {
+                MaterialTheme.colorScheme.tertiaryContainer
+            }
         ),
         shape = RoundedCornerShape(20.dp),
         modifier = modifier
@@ -64,7 +67,11 @@ fun RulesListItem(
                     modifier = Modifier
                         .background(
                             shape = getShapeForRule(rule.mutationType),
-                            color = MaterialTheme.colorScheme.secondary
+                            color = if (!isSelected) {
+                                MaterialTheme.colorScheme.secondary
+                            } else {
+                                MaterialTheme.colorScheme.tertiary
+                            }
                         )
                         .size(40.dp)
                 )
@@ -74,9 +81,6 @@ fun RulesListItem(
             ),
             modifier = Modifier
                 .padding(4.dp)
-                .clickable {
-                    onClick(rule)
-                }
                 .semantics {
                     testTag = "Rules List Item ${rule.baseRuleId}"
                 }
@@ -90,7 +94,7 @@ private fun ItemPreview() {
     PreviewContainer {
         RulesListItem(
             rule = PreviewData.previewRules[1],
-            onClick = { /* do nothing */ },
+            isSelected = false,
             modifier = Modifier.padding(8.dp)
         )
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
@@ -67,10 +67,11 @@ fun RulesListItem(
                 )
             },
             leadingContent = {
+                val (shape, shapeSemantics) = getShapeForRule(rule.mutationType)
                 Box(
                     modifier = Modifier
                         .background(
-                            shape = getShapeForRule(rule.mutationType),
+                            shape = shape,
                             color = if (!isSelected) {
                                 MaterialTheme.colorScheme.secondary
                             } else {
@@ -78,7 +79,10 @@ fun RulesListItem(
                             }
                         )
                         .size(40.dp)
-                        .semantics { testTag = "Shape for ${rule.mutationType.name}" }
+                        .semantics {
+                            shapeSemantics()
+                            testTag = "Shape for ${rule.mutationType.name}"
+                        }
                 )
             },
             colors = ListItemDefaults.colors(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -42,7 +43,10 @@ fun RulesListItem(
             }
         ),
         shape = RoundedCornerShape(20.dp),
-        modifier = modifier
+        modifier = modifier.semantics {
+            selected = isSelected
+            testTag = "Rules List Item ${rule.baseRuleId}"
+        }
     ) {
         ListItem(
             headlineContent = {
@@ -74,16 +78,13 @@ fun RulesListItem(
                             }
                         )
                         .size(40.dp)
+                        .semantics { testTag = "Shape for ${rule.mutationType.name}" }
                 )
             },
             colors = ListItemDefaults.colors(
                 containerColor = Color.Transparent
             ),
-            modifier = Modifier
-                .padding(4.dp)
-                .semantics {
-                    testTag = "Rules List Item ${rule.baseRuleId}"
-                }
+            modifier = Modifier.padding(4.dp)
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -16,7 +15,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
@@ -24,27 +22,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
-import com.suvanl.fixmylinks.ui.graphics.CustomShapes.CloverShape
-import com.suvanl.fixmylinks.ui.graphics.CustomShapes.DeltaShape
-import com.suvanl.fixmylinks.ui.graphics.CustomShapes.EightPointStarShape
-import com.suvanl.fixmylinks.ui.graphics.CustomShapes.ScallopShape
 import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 import com.suvanl.fixmylinks.ui.util.PreviewData
-
-/**
- * Returns the shape used to represent the given rule type in the UI.
- */
-private fun getShapeForRule(ruleType: MutationType): Shape = when (ruleType) {
-    MutationType.DOMAIN_NAME -> RoundedCornerShape(10.dp)
-    MutationType.URL_PARAMS_ALL -> ScallopShape
-    MutationType.URL_PARAMS_SPECIFIC -> DeltaShape
-    MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> CloverShape
-    MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> EightPointStarShape
-    MutationType.FALLBACK -> CircleShape
-}
+import com.suvanl.fixmylinks.ui.util.getShapeForRule
 
 @Composable
 fun RulesListItem(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/SwitchListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/SwitchListItem.kt
@@ -1,6 +1,12 @@
 package com.suvanl.fixmylinks.ui.components.list
 
 import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material3.Icon
@@ -10,11 +16,13 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 
@@ -24,7 +32,8 @@ data class SwitchListItemState(
     val leadingIcon: ImageVector,
     val isSwitchChecked: Boolean,
     val onSwitchCheckedChange: (Boolean) -> Unit,
-    val isSwitchEnabled: Boolean = true
+    val comingSoon: Boolean = false,
+    val isSwitchEnabled: Boolean = !comingSoon,
 )
 
 @Composable
@@ -34,12 +43,34 @@ fun SwitchListItem(
 ) {
     ListItem(
         headlineContent = {
-            Text(
-                text = listItemState.headlineText,
-                style = MaterialTheme.typography.titleLarge,
-                fontSize = 17.sp,
-                fontWeight = FontWeight.SemiBold
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = listItemState.headlineText,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontSize = 17.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+
+                if (listItemState.comingSoon) {
+                    Box(
+                        modifier = Modifier
+                            .background(
+                                color = MaterialTheme.colorScheme.tertiaryContainer,
+                                shape = RoundedCornerShape(4.dp)
+                            )
+                            .padding(4.dp)
+                    ) {
+                        Text(
+                            text = "Coming soon".uppercase(),
+                            maxLines = 1,
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    }
+                }
+            }
         },
         supportingContent = {
             Text(
@@ -112,6 +143,32 @@ fun SwitchListItemOffPreview() {
                 leadingIcon = Icons.Outlined.AutoAwesome,
                 isSwitchChecked = false,
                 onSwitchCheckedChange = {}
+            )
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 320
+)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    widthDp = 320,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+fun SwitchListItemComingSoonPreview() {
+    PreviewContainer {
+        SwitchListItem(
+            listItemState = SwitchListItemState(
+                headlineText = "Headline",
+                supportingText = "Supporting text",
+                leadingIcon = Icons.Outlined.AutoAwesome,
+                isSwitchChecked = false,
+                onSwitchCheckedChange = {},
+                comingSoon = true
             )
         )
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/graphics/CustomShapes.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/graphics/CustomShapes.kt
@@ -5,7 +5,6 @@ import androidx.graphics.shapes.RoundedPolygon
 /**
  * Custom Material 3-style shapes, such as 'scallop', 'clover', wavy circle' etc.
  */
-@Suppress("unused")
 object CustomShapes {
     val ScallopPolygon = genPolygon(PolygonParams.ScallopParams, ShapeParameters.ShapeId.Star)
     val ScallopShape = RoundedPolygonShape(ScallopPolygon)

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -42,6 +42,7 @@ import com.suvanl.fixmylinks.ui.screens.SavedScreen
 import com.suvanl.fixmylinks.ui.screens.details.RuleDetailsScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreenUiState
+import com.suvanl.fixmylinks.ui.screens.newruleflow.RuleOptionsState
 import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
 import com.suvanl.fixmylinks.ui.theme.TextStyleDefaults
 import com.suvanl.fixmylinks.ui.util.getNewRuleFlowViewModel
@@ -285,6 +286,7 @@ fun FmlNavHost(
                         mutationType = mutationType,
                         showFormFieldHints = userPreferences.showFormFieldHints,
                         showSaveButton = isCompactLayout,
+                        ruleOptions = RuleOptionsState(),
                     ),
                     viewModel = viewModel,
                     onSaveClick = { handleSaveRuleClick() },

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -52,7 +52,7 @@ import com.suvanl.fixmylinks.ui.screens.newruleflow.RuleOptionsState
 import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
 import com.suvanl.fixmylinks.ui.theme.TextStyleDefaults
 import com.suvanl.fixmylinks.ui.util.getNewRuleFlowViewModel
-import com.suvanl.fixmylinks.viewmodel.MainViewModel
+import com.suvanl.fixmylinks.viewmodel.AppLevelViewModel
 import com.suvanl.fixmylinks.viewmodel.RulesViewModel
 import com.suvanl.fixmylinks.viewmodel.newruleflow.AddRuleViewModel
 import com.suvanl.fixmylinks.viewmodel.newruleflow.SelectRuleTypeViewModel
@@ -65,7 +65,7 @@ fun FmlNavHost(
     navController: NavHostController,
     windowWidthSize: WindowWidthSizeClass,
     modifier: Modifier = Modifier,
-    mainViewModel: MainViewModel = hiltViewModel(),
+    mainViewModel: AppLevelViewModel = hiltViewModel(),
 ) {
     NavHost(
         navController = navController,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -46,6 +46,7 @@ import com.suvanl.fixmylinks.ui.screens.newruleflow.RuleOptionsState
 import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
 import com.suvanl.fixmylinks.ui.theme.TextStyleDefaults
 import com.suvanl.fixmylinks.ui.util.getNewRuleFlowViewModel
+import com.suvanl.fixmylinks.viewmodel.MainViewModel
 import com.suvanl.fixmylinks.viewmodel.RulesViewModel
 import com.suvanl.fixmylinks.viewmodel.newruleflow.AddRuleViewModel
 import com.suvanl.fixmylinks.viewmodel.newruleflow.SelectRuleTypeViewModel
@@ -57,7 +58,8 @@ import kotlinx.coroutines.launch
 fun FmlNavHost(
     navController: NavHostController,
     windowWidthSize: WindowWidthSizeClass,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    mainViewModel: MainViewModel = hiltViewModel(),
 ) {
     NavHost(
         navController = navController,
@@ -94,6 +96,10 @@ fun FmlNavHost(
 
                 val coroutineScope = rememberCoroutineScope()
 
+                LaunchedEffect(key1 = Unit) {
+                    mainViewModel.resetState()
+                }
+
                 RulesScreen(
                     uiState = uiState,
                     onClickRuleItem = { rule ->
@@ -108,7 +114,10 @@ fun FmlNavHost(
                                 popUpToStartDestination = false
                             )
                         }
-                    }
+                    },
+                    onUpdateSelectedItems = {
+                        mainViewModel.updateMultiSelectedRules(it)
+                    },
                 )
             }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -110,7 +110,14 @@ fun FmlNavHost(
                     IconButton(
                         onClick = {
                             coroutineScope.launch {
-                                selectedRules.forEach { viewModel.deleteSingleRule(it.baseRuleId) }
+                                val allRulesSelected = selectedRules == uiState.rules.toSet()
+                                if (!allRulesSelected) {
+                                    selectedRules.forEach {
+                                        viewModel.deleteSingleRule(it.baseRuleId)
+                                    }
+                                } else {
+                                    viewModel.deleteAllRules()
+                                }
 
                                 // Clear selection
                                 mainViewModel.updateMultiSelectedRules(setOf())

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -124,7 +124,10 @@ fun FmlNavHost(
                     }
 
                     IconButton(
-                        onClick = { /*TODO*/ }
+                        onClick = {
+                            // Add all rules to selected set
+                            mainViewModel.updateMultiSelectedRules(uiState.rules.toSet())
+                        }
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.SelectAll,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -119,7 +119,7 @@ fun FmlNavHost(
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.Delete,
-                            contentDescription = "Delete selected"
+                            contentDescription = stringResource(R.string.delete_selected)
                         )
                     }
 
@@ -131,7 +131,7 @@ fun FmlNavHost(
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.SelectAll,
-                            contentDescription = "Select all"
+                            contentDescription = stringResource(R.string.select_all)
                         )
                     }
                 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -2,8 +2,13 @@ package com.suvanl.fixmylinks.ui.navigation
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.SelectAll
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
@@ -93,11 +98,39 @@ fun FmlNavHost(
             composable(route = FmlScreen.Rules.route) { navBackStackEntry ->
                 val viewModel = navBackStackEntry.sharedViewModel<RulesViewModel>(navController)
                 val uiState by viewModel.rulesScreenUiState.collectAsStateWithLifecycle()
+                val selectedRules by mainViewModel.multiSelectedRules.collectAsStateWithLifecycle()
 
                 val coroutineScope = rememberCoroutineScope()
 
                 LaunchedEffect(key1 = Unit) {
                     mainViewModel.resetState()
+                }
+
+                ProvideAppBarActions {
+                    IconButton(
+                        onClick = {
+                            coroutineScope.launch {
+                                selectedRules.forEach { viewModel.deleteSingleRule(it.baseRuleId) }
+
+                                // Clear selection
+                                mainViewModel.updateMultiSelectedRules(setOf())
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Delete,
+                            contentDescription = "Delete selected"
+                        )
+                    }
+
+                    IconButton(
+                        onClick = { /*TODO*/ }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.SelectAll,
+                            contentDescription = "Select all"
+                        )
+                    }
                 }
 
                 RulesScreen(
@@ -115,6 +148,7 @@ fun FmlNavHost(
                             )
                         }
                     },
+                    selectedItems = selectedRules,
                     onUpdateSelectedItems = {
                         mainViewModel.updateMultiSelectedRules(it)
                     },

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlScreen.kt
@@ -115,6 +115,14 @@ val addNewRuleFlowScreens = setOf(
 )
 
 /**
+ * Screens that are part of the "rule details" flow, excluding top-level destinations (i.e.,
+ * [FmlScreen.Rules]).
+ */
+val ruleDetailsFlowScreens = setOf(
+    FmlScreen.RuleDetails,
+)
+
+/**
  * Returns the base of a route (i.e., the route without any arguments)
  */
 fun getBaseRoute(route: String?): String {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
@@ -8,11 +8,13 @@ import androidx.compose.animation.core.spring
 import androidx.navigation.NavBackStackEntry
 import com.suvanl.fixmylinks.ui.navigation.addNewRuleFlowScreens
 import com.suvanl.fixmylinks.ui.navigation.getBaseRoute
+import com.suvanl.fixmylinks.ui.navigation.ruleDetailsFlowScreens
 import com.suvanl.fixmylinks.ui.util.topLevelScreensWithFab
 
 enum class NavigationEnterTransitionMode { ENTER, POP_ENTER }
 enum class NavigationExitTransitionMode { EXIT, POP_EXIT }
 
+private val userFlowScreens = listOf(addNewRuleFlowScreens, ruleDetailsFlowScreens).flatten()
 
 /**
  * Returns the appropriate navigation [ExitTransition] based on the given [transitionMode] and the
@@ -28,13 +30,13 @@ fun exitNavigationTransition(
     // Whether we're navigating from a screen within the "add new rule" flow to a top-level screen
     // that has a FAB
     val isNavigatingFromFlowToTopLevelScreen =
-        addNewRuleFlowScreens.any { it.route == initialDestinationRoute }
+        userFlowScreens.any { it.route == initialDestinationRoute }
                 && topLevelScreensWithFab.any { it.route == targetDestinationRoute }
 
     // If the target destination is part of the "add new rule" flow, or if we're navigating back to
     // a screen that this flow could've been started from
     return if (
-        addNewRuleFlowScreens.any { it.route == targetDestinationRoute }
+        userFlowScreens.any { it.route == targetDestinationRoute }
         || isNavigatingFromFlowToTopLevelScreen
     ) {
         // Perform slide out animation when navigating from an initial state of a screen that is
@@ -84,11 +86,11 @@ fun enterNavigationTransition(
     // flow, or if we're performing intra-flow navigation, use the slide animation
     val isNavigatingFromTopLevelDestinationToFlow =
         topLevelScreensWithFab.any { it.route == initialDestinationRoute }
-                && addNewRuleFlowScreens.any { it.route == targetDestinationRoute }
+                && userFlowScreens.any { it.route == targetDestinationRoute }
 
     // Inverse of isNavigatingFromTopLevelDestinationToFlow
     val isNavigatingFromFlowToTopLevelDestination =
-        addNewRuleFlowScreens.any { it.route == initialDestinationRoute }
+        userFlowScreens.any { it.route == initialDestinationRoute }
                 && topLevelScreensWithFab.any { it.route == targetDestinationRoute }
 
     return if (

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -1,5 +1,6 @@
 package com.suvanl.fixmylinks.ui.screens
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -38,6 +39,7 @@ import androidx.navigation.compose.rememberNavController
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.ui.components.appbar.FmlTopAppBar
+import com.suvanl.fixmylinks.ui.components.appbar.RuleSelectionTopAppBar
 import com.suvanl.fixmylinks.ui.components.appbar.TopAppBarSize
 import com.suvanl.fixmylinks.ui.components.button.AddNewRuleFab
 import com.suvanl.fixmylinks.ui.components.button.EditFab
@@ -125,7 +127,16 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
                         modifier = Modifier.fillMaxWidth()
                     )
                 } else if (shouldShowRulesMultiSelectTopAppBar) {
-                    TODO("Show selection appbar")
+                    RuleSelectionTopAppBar(
+                        selectedItemsSize = multiSelectedRules.size,
+                        currentBackStackEntryFlow = navController.currentBackStackEntryFlow,
+                        onDismiss = mainViewModel::clearMultiSelectedRules,
+                    )
+
+                    // Clear selection on system back gesture/press
+                    BackHandler(enabled = multiSelectedRules.isNotEmpty()) {
+                        mainViewModel.clearMultiSelectedRules()
+                    }
                 }
             },
             bottomBar = {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.suvanl.fixmylinks.R
@@ -50,11 +52,16 @@ import com.suvanl.fixmylinks.ui.navigation.navigateSingleTop
 import com.suvanl.fixmylinks.ui.theme.FixMyLinksTheme
 import com.suvanl.fixmylinks.ui.util.topLevelScreens
 import com.suvanl.fixmylinks.ui.util.topLevelScreensWithFab
+import com.suvanl.fixmylinks.viewmodel.MainViewModel
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun FixMyLinksApp(windowSize: WindowSizeClass) {
     val navController = rememberNavController()
+    val mainViewModel = hiltViewModel<MainViewModel>()
+
+    // Currently selected rule items on RulesScreen
+    val multiSelectedRules by mainViewModel.multiSelectedRules.collectAsStateWithLifecycle()
 
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
@@ -88,13 +95,16 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
         else -> false
     } && showNavBarOn.any { it.route == currentBaseRoute }
 
-    val shouldShowSearchBar = showSearchBarOn.any { it.route == currentBaseRoute }
+    val shouldShowSearchBar = showSearchBarOn.any { it.route == currentBaseRoute } && multiSelectedRules.isEmpty()
     val shouldShowDockedSearchBar = shouldShowSearchBar
             && windowSize.widthSizeClass != WindowWidthSizeClass.Compact
 
     val shouldShowTopAppBar = showNavBarOn.none { it.route == currentBaseRoute }
     val shouldShowAddNewRuleFab = topLevelScreensWithFab.any { it.route == currentBaseRoute }
     val shouldShowEditRuleFab = currentBaseRoute.startsWith(FmlScreen.RuleDetails.route)
+
+    val shouldShowRulesMultiSelectTopAppBar =
+        currentBaseRoute == FmlScreen.Rules.route && multiSelectedRules.isNotEmpty()
 
     FixMyLinksTheme {
         Scaffold(
@@ -114,6 +124,8 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
                         horizontalPadding = 16.dp,
                         modifier = Modifier.fillMaxWidth()
                     )
+                } else if (shouldShowRulesMultiSelectTopAppBar) {
+                    TODO("Show selection appbar")
                 }
             },
             bottomBar = {
@@ -227,7 +239,8 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
 
                         FmlNavHost(
                             navController = navController,
-                            windowWidthSize = windowSize.widthSizeClass
+                            windowWidthSize = windowSize.widthSizeClass,
+                            mainViewModel = mainViewModel,
                         )
                     }
                 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
@@ -38,13 +38,13 @@ data class RulesScreenUiState(
 fun RulesScreen(
     uiState: RulesScreenUiState,
     onClickRuleItem: (BaseMutationModel) -> Unit,
+    onUpdateSelectedItems: (Set<BaseMutationModel>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RulesScreenBody(
         uiState = uiState,
-        onClickItem = { rule ->
-            onClickRuleItem(rule)
-        },
+        onClickItem = onClickRuleItem,
+        onUpdateSelectedItems = onUpdateSelectedItems,
         modifier = modifier
     )
 }
@@ -53,6 +53,7 @@ fun RulesScreen(
 private fun RulesScreenBody(
     uiState: RulesScreenUiState,
     onClickItem: (BaseMutationModel) -> Unit,
+    onUpdateSelectedItems: (Set<BaseMutationModel>) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val hasRules = uiState.rules.isNotEmpty()
@@ -74,7 +75,8 @@ private fun RulesScreenBody(
 
         RulesList(
             uiState = uiState,
-            onClickItem = onClickItem
+            onClickItem = onClickItem,
+            onUpdateSelectedItems = onUpdateSelectedItems,
         )
     }
 }
@@ -126,7 +128,8 @@ private fun RulesScreenPreview() {
     PreviewContainer {
         RulesScreenBody(
             uiState = RulesScreenUiState(rules = PreviewData.previewRules),
-            onClickItem = { /* do nothing */ },
+            onClickItem = {},
+            onUpdateSelectedItems = {},
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
@@ -10,9 +10,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Link
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,6 +29,7 @@ import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
 import com.suvanl.fixmylinks.ui.components.list.RulesList
 import com.suvanl.fixmylinks.ui.graphics.CustomShapes.ScallopPolygon
 import com.suvanl.fixmylinks.ui.layout.Polygon
+import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 import com.suvanl.fixmylinks.ui.util.PreviewData
 
@@ -115,6 +118,41 @@ private fun EmptyRulesBody(
             style = MaterialTheme.typography.titleLarge
         )
     }
+}
+
+@Composable
+fun DeleteSelectionConfirmationDialog(
+    onDismissRequest: () -> Unit,
+    onConfirmDelete: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AlertDialog(
+        title = {
+            Text(
+                text = stringResource(R.string.delete_selected_rules),
+                letterSpacing = LetterSpacingDefaults.Tighter,
+            )
+        },
+        text = {
+            Text(text = stringResource(R.string.delete_selected_rules_description))
+        },
+        dismissButton = {
+            TextButton(
+                onClick = { onDismissRequest() }
+            ) {
+                Text(text = stringResource(id = android.R.string.cancel))
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onConfirmDelete() }
+            ) {
+                Text(text = stringResource(id = R.string.delete))
+            }
+        },
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.semantics { testTag = "Delete Selected Confirmation Dialog" }
+    )
 }
 
 @Preview(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
@@ -38,12 +38,14 @@ data class RulesScreenUiState(
 fun RulesScreen(
     uiState: RulesScreenUiState,
     onClickRuleItem: (BaseMutationModel) -> Unit,
+    selectedItems: Set<BaseMutationModel>,
     onUpdateSelectedItems: (Set<BaseMutationModel>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     RulesScreenBody(
         uiState = uiState,
         onClickItem = onClickRuleItem,
+        selectedItems = selectedItems,
         onUpdateSelectedItems = onUpdateSelectedItems,
         modifier = modifier
     )
@@ -53,6 +55,7 @@ fun RulesScreen(
 private fun RulesScreenBody(
     uiState: RulesScreenUiState,
     onClickItem: (BaseMutationModel) -> Unit,
+    selectedItems: Set<BaseMutationModel>,
     onUpdateSelectedItems: (Set<BaseMutationModel>) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -76,6 +79,7 @@ private fun RulesScreenBody(
         RulesList(
             uiState = uiState,
             onClickItem = onClickItem,
+            selectedItems = selectedItems,
             onUpdateSelectedItems = onUpdateSelectedItems,
         )
     }
@@ -129,6 +133,7 @@ private fun RulesScreenPreview() {
         RulesScreenBody(
             uiState = RulesScreenUiState(rules = PreviewData.previewRules),
             onClickItem = {},
+            selectedItems = setOf(),
             onUpdateSelectedItems = {},
         )
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -48,6 +48,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -88,6 +91,7 @@ fun RuleDetailsScreen(
         modifier = modifier
             .fillMaxSize()
             .padding(horizontal = 16.dp)
+            .semantics { contentDescription = "Rule Details Screen" }
     ) {
         if (showDeleteConfirmation) {
             DeleteConfirmationDialog(
@@ -329,7 +333,7 @@ private fun DeleteConfirmationDialog(
             }
         },
         onDismissRequest = onDismissRequest,
-        modifier = modifier
+        modifier = modifier.semantics { testTag = "Delete Confirmation Dialog" }
     )
 }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -1,20 +1,63 @@
 package com.suvanl.fixmylinks.ui.screens.details
 
+import android.content.res.Configuration
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.EaseOutExpo
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Backup
+import androidx.compose.material.icons.outlined.CloudOff
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Language
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
+import com.suvanl.fixmylinks.ui.components.list.RuleDetailsList
+import com.suvanl.fixmylinks.ui.components.list.RuleDetailsListItemState
 import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.ui.util.PreviewData
+import com.suvanl.fixmylinks.ui.util.getShapeForRule
 
 /**
  * Displays additional info about the rule compared to that of
@@ -50,13 +93,188 @@ fun RuleDetailsScreen(
             )
         }
 
-        Text(text = "Rule details")
-        Text(text = "type: ${rule.mutationType}")
-        Text(text = "base rule ID: ${rule.baseRuleId}")
-
         Spacer(modifier = Modifier.height(16.dp))
 
-        Text(text = "Name: ${rule.name}; On: ${rule.triggerDomain}")
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                    shape = RoundedCornerShape(50.dp)
+                )
+                .padding(
+                    horizontal = 20.dp,
+                    vertical = 20.dp
+                )
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(50.dp)
+                    .background(
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        shape = getShapeForRule(rule.mutationType)
+                    )
+            )
+
+            Column(
+                modifier = Modifier.weight(1F)
+            ) {
+                Text(text = "This rule", style = MaterialTheme.typography.bodyMedium)
+                Text(text = rule.mutationType.name.lowercase(), maxLines = 1)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // General details
+        RuleDetailsExpandingCard(rule = rule)
+    }
+}
+
+@Composable
+private fun RuleDetailsExpandingCard(
+    rule: BaseMutationModel,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(true) }
+
+    val arrowRotationAngle by animateFloatAsState(
+        targetValue = if (!expanded) 0F else 180F,
+        label = "arrow rotation",
+        animationSpec = tween(
+            durationMillis = 400,
+            easing = EaseOutExpo,
+        )
+    )
+
+    val cardShapeCornerRadius by animateDpAsState(
+        targetValue = if (expanded) 50.dp else 30.dp,
+        label = "card shape corner radius",
+        animationSpec = tween(
+            durationMillis = 700,
+            delayMillis = 150
+        )
+    )
+
+    Card(
+        shape = RoundedCornerShape(cardShapeCornerRadius),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.inverseOnSurface
+        ),
+        modifier = modifier.fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(20.dp)
+                .animateContentSize(
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioLowBouncy,
+                        stiffness = Spring.StiffnessLow,
+                    )
+                )
+        ) {
+            // Heading / expand button row
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 2.dp)
+                    .clickable(
+                        // Hide ripple effect
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() }
+                    ) {
+                        expanded = !expanded
+                    }
+            ) {
+                Icon(imageVector = Icons.Outlined.Info, contentDescription = null)
+                Text(
+                    text = "General",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1F)
+                )
+                Box(
+                    modifier = Modifier
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = CircleShape
+                        )
+                        .padding(2.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.ExpandMore,
+                        contentDescription = if (expanded) {
+                            stringResource(R.string.collapse_details)
+                        } else {
+                            stringResource(R.string.expand_details)
+                        },
+                        modifier = Modifier.rotate(arrowRotationAngle)
+                    )
+                }
+            }
+
+            // Details content
+            if (expanded) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                RuleDetailsList(
+                    details = listOf(
+                        RuleDetailsListItemState(
+                            headlineText = rule.name,
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Description,
+                                    contentDescription = stringResource(R.string.content_desc_rule_name)
+                                )
+                            },
+                        ),
+                        RuleDetailsListItemState(
+                            headlineText = rule.triggerDomain,
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Language,
+                                    contentDescription = stringResource(R.string.content_desc_domain_name)
+                                )
+                            },
+                        ),
+                        RuleDetailsListItemState(
+                            headlineText = if (rule.isLocalOnly) {
+                                stringResource(R.string.not_backed_up)
+                            } else {
+                                stringResource(R.string.backed_up)
+                            },
+                            leadingIcon = {
+                                if (rule.isLocalOnly) {
+                                    Icon(
+                                        imageVector = Icons.Outlined.CloudOff,
+                                        contentDescription = stringResource(R.string.content_desc_backup_off)
+                                    )
+                                } else {
+                                    Icon(
+                                        imageVector = Icons.Outlined.Backup,
+                                        contentDescription = stringResource(R.string.content_desc_backup_on)
+                                    )
+                                }
+                            },
+                        ),
+                        RuleDetailsListItemState(
+                            headlineText = "A week ago",
+                            supportingText = rule.dateModifiedTimestamp.toString(),
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Outlined.Schedule,
+                                    contentDescription = stringResource(R.string.content_desc_last_modified)
+                                )
+                            },
+                        ),
+                    )
+                )
+            }
+        }
     }
 }
 
@@ -93,4 +311,26 @@ private fun DeleteConfirmationDialog(
         onDismissRequest = onDismissRequest,
         modifier = modifier
     )
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 400
+)
+@Preview(
+    name = "Dark",
+    showBackground = true,
+    widthDp = 400,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun RuleDetailsScreenPreview() {
+    PreviewContainer {
+        RuleDetailsScreen(
+            rule = PreviewData.previewRules.first(),
+            showDeleteConfirmation = false,
+            onDismissDeleteConfirmation = { },
+            onDelete = { },
+        )
+    }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -122,7 +122,7 @@ fun RuleDetailsScreen(
                     .size(50.dp)
                     .background(
                         color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        shape = getShapeForRule(rule.mutationType)
+                        shape = getShapeForRule(rule.mutationType).shape
                     )
             )
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -50,7 +51,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
 import com.suvanl.fixmylinks.ui.components.list.RuleDetailsList
 import com.suvanl.fixmylinks.ui.components.list.RuleDetailsListItemState
@@ -95,6 +98,7 @@ fun RuleDetailsScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
+        // Rule type description
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -121,8 +125,24 @@ fun RuleDetailsScreen(
             Column(
                 modifier = Modifier.weight(1F)
             ) {
-                Text(text = "This rule", style = MaterialTheme.typography.bodyMedium)
-                Text(text = rule.mutationType.name.lowercase(), maxLines = 1)
+                val ruleTypeInfo = getRuleTypeInPresentSimpleTense(ruleType = rule.mutationType)
+                var lineCount by remember { mutableIntStateOf(0) }
+
+                if (lineCount < 2) {
+                    Text(text = "This rule", style = MaterialTheme.typography.bodyMedium)
+                }
+
+                Text(
+                    text = ruleTypeInfo,
+                    maxLines = 2,
+                    letterSpacing = when (ruleTypeInfo.length) {
+                        in 20..29 -> LetterSpacingDefaults.Tight
+                        in 30..39 -> LetterSpacingDefaults.Tighter
+                        in 40..Int.MAX_VALUE -> LetterSpacingDefaults.ExtraTight
+                        else -> 0.sp
+                    },
+                    onTextLayout = { lineCount = it.lineCount }
+                )
             }
         }
 
@@ -311,6 +331,33 @@ private fun DeleteConfirmationDialog(
         onDismissRequest = onDismissRequest,
         modifier = modifier
     )
+}
+
+@Composable
+private fun getRuleTypeInPresentSimpleTense(ruleType: MutationType) = when (ruleType) {
+    MutationType.DOMAIN_NAME -> {
+        stringResource(id = R.string.mt_domain_name_present_simple_tense)
+    }
+
+    MutationType.URL_PARAMS_ALL -> {
+        stringResource(id = R.string.mt_url_params_all_present_simple_tense)
+    }
+
+    MutationType.URL_PARAMS_SPECIFIC -> {
+        stringResource(id = R.string.mt_url_params_specific_present_simple_tense)
+    }
+
+    MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
+        stringResource(id = R.string.mt_domain_name_and_url_params_all_present_simple_tense)
+    }
+
+    MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> {
+        TODO("Not user-selectable yet")
+    }
+
+    MutationType.FALLBACK -> {
+        throw IllegalArgumentException("MutationType.FALLBACK should not be user-selectable")
+    }
 }
 
 @Preview(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -85,6 +85,7 @@ fun AddRuleScreen(
             leadingIcon = Icons.Outlined.Backup,
             isSwitchChecked = isBackupEnabled,
             onSwitchCheckedChange = { isBackupEnabled = it },
+            comingSoon = true,
         ),
     )
 
@@ -297,6 +298,7 @@ fun AddRuleScreenPreview() {
                 leadingIcon = Icons.Outlined.Backup,
                 isSwitchChecked = false,
                 onSwitchCheckedChange = {},
+                comingSoon = true,
             )
         )
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Backup
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Segment
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -69,6 +70,7 @@ fun AddRuleScreen(
     baseRuleId: Long = 0,
 ) {
     var isRuleEnabled by rememberSaveable { mutableStateOf(true) }
+    var isKeepContentEnabled by rememberSaveable { mutableStateOf(false) }
     var isBackupEnabled by rememberSaveable { mutableStateOf(false) }
 
     val ruleOptions = listOf(
@@ -80,7 +82,15 @@ fun AddRuleScreen(
             onSwitchCheckedChange = { isRuleEnabled = it },
         ),
         SwitchListItemState(
-            headlineText = stringResource(R.string.backup_to_cloud),
+            headlineText = stringResource(R.string.keep_content),
+            supportingText = stringResource(R.string.keep_content_supporting_text),
+            leadingIcon = Icons.Outlined.Segment,
+            isSwitchChecked = isKeepContentEnabled,
+            onSwitchCheckedChange = { isKeepContentEnabled = it },
+            comingSoon = true,
+        ),
+        SwitchListItemState(
+            headlineText = "Keep content",
             supportingText = stringResource(R.string.backup_to_cloud_supporting_text),
             leadingIcon = Icons.Outlined.Backup,
             isSwitchChecked = isBackupEnabled,
@@ -291,6 +301,14 @@ fun AddRuleScreenPreview() {
                 leadingIcon = Icons.Outlined.CheckCircle,
                 isSwitchChecked = true,
                 onSwitchCheckedChange = {},
+            ),
+            SwitchListItemState(
+                headlineText = stringResource(R.string.keep_content),
+                supportingText = stringResource(R.string.keep_content_supporting_text),
+                leadingIcon = Icons.Outlined.Segment,
+                isSwitchChecked = false,
+                onSwitchCheckedChange = {},
+                comingSoon = true,
             ),
             SwitchListItemState(
                 headlineText = stringResource(R.string.backup_to_cloud),

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/UiUtils.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/UiUtils.kt
@@ -3,18 +3,45 @@ package com.suvanl.fixmylinks.ui.util
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.ui.graphics.CustomShapes
 
 /**
+ * A [Shape] with optional semantics properties for accessibility/testing purposes.
+ */
+data class UiShape(
+    val shape: Shape,
+    val semantics: SemanticsPropertyReceiver.() -> Unit = {},
+)
+
+/**
  * Returns the shape used to represent the given rule type in the UI.
  */
-fun getShapeForRule(ruleType: MutationType): Shape = when (ruleType) {
-    MutationType.DOMAIN_NAME -> RoundedCornerShape(10.dp)
-    MutationType.URL_PARAMS_ALL -> CustomShapes.ScallopShape
-    MutationType.URL_PARAMS_SPECIFIC -> CustomShapes.DeltaShape
-    MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> CustomShapes.CloverShape
-    MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> CustomShapes.EightPointStarShape
-    MutationType.FALLBACK -> CircleShape
+fun getShapeForRule(ruleType: MutationType): UiShape = when (ruleType) {
+    MutationType.DOMAIN_NAME -> {
+        UiShape(RoundedCornerShape(10.dp)) { contentDescription = "Square" }
+    }
+
+    MutationType.URL_PARAMS_ALL -> {
+        UiShape(CustomShapes.ScallopShape) { contentDescription = "Scallop" }
+    }
+
+    MutationType.URL_PARAMS_SPECIFIC -> {
+        UiShape(CustomShapes.DeltaShape) { contentDescription = "Delta" }
+    }
+
+    MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
+        UiShape(CustomShapes.CloverShape) { contentDescription = "Clover" }
+    }
+
+    MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> {
+        UiShape(CustomShapes.EightPointStarShape) { contentDescription = "Eight-point star" }
+    }
+
+    MutationType.FALLBACK -> {
+        UiShape(CircleShape) { contentDescription = "Circle" }
+    }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/UiUtils.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/UiUtils.kt
@@ -1,0 +1,20 @@
+package com.suvanl.fixmylinks.ui.util
+
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.ui.graphics.CustomShapes
+
+/**
+ * Returns the shape used to represent the given rule type in the UI.
+ */
+fun getShapeForRule(ruleType: MutationType): Shape = when (ruleType) {
+    MutationType.DOMAIN_NAME -> RoundedCornerShape(10.dp)
+    MutationType.URL_PARAMS_ALL -> CustomShapes.ScallopShape
+    MutationType.URL_PARAMS_SPECIFIC -> CustomShapes.DeltaShape
+    MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> CustomShapes.CloverShape
+    MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> CustomShapes.EightPointStarShape
+    MutationType.FALLBACK -> CircleShape
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/AppLevelViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/AppLevelViewModel.kt
@@ -1,0 +1,21 @@
+package com.suvanl.fixmylinks.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
+import kotlinx.coroutines.flow.StateFlow
+
+abstract class AppLevelViewModel : ViewModel() {
+
+    /**
+     * An observable [Set] of rules that have been selected by the user on `FmlScreen.Rules`
+     */
+    abstract val multiSelectedRules: StateFlow<Set<BaseMutationModel>>
+
+    abstract fun updateMultiSelectedRules(updatedSet: Set<BaseMutationModel>)
+
+    abstract fun clearMultiSelectedRules()
+
+    fun resetState() {
+        clearMultiSelectedRules()
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/MainViewModel.kt
@@ -1,6 +1,5 @@
 package com.suvanl.fixmylinks.viewmodel
 
-import androidx.lifecycle.ViewModel
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,19 +11,15 @@ import javax.inject.Inject
  * between the app-level composable and the NavHost.
  */
 @HiltViewModel
-class MainViewModel @Inject constructor() : ViewModel() {
+class MainViewModel @Inject constructor() : AppLevelViewModel() {
     private val _multiSelectedRules = MutableStateFlow(setOf<BaseMutationModel>())
-    val multiSelectedRules = _multiSelectedRules.asStateFlow()
+    override val multiSelectedRules = _multiSelectedRules.asStateFlow()
 
-    fun updateMultiSelectedRules(updatedSet: Set<BaseMutationModel>) {
+    override fun updateMultiSelectedRules(updatedSet: Set<BaseMutationModel>) {
         _multiSelectedRules.value = updatedSet
     }
 
-    fun clearMultiSelectedRules() {
+    override fun clearMultiSelectedRules() {
         _multiSelectedRules.value = setOf()
-    }
-
-    fun resetState() {
-        clearMultiSelectedRules()
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/MainViewModel.kt
@@ -20,7 +20,11 @@ class MainViewModel @Inject constructor() : ViewModel() {
         _multiSelectedRules.value = updatedSet
     }
 
-    fun resetState() {
+    fun clearMultiSelectedRules() {
         _multiSelectedRules.value = setOf()
+    }
+
+    fun resetState() {
+        clearMultiSelectedRules()
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/MainViewModel.kt
@@ -1,0 +1,26 @@
+package com.suvanl.fixmylinks.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+/**
+ * A ViewModel scoped to the lifetime of the app-level composable, responsible for sharing state
+ * between the app-level composable and the NavHost.
+ */
+@HiltViewModel
+class MainViewModel @Inject constructor() : ViewModel() {
+    private val _multiSelectedRules = MutableStateFlow(setOf<BaseMutationModel>())
+    val multiSelectedRules = _multiSelectedRules.asStateFlow()
+
+    fun updateMultiSelectedRules(updatedSet: Set<BaseMutationModel>) {
+        _multiSelectedRules.value = updatedSet
+    }
+
+    fun resetState() {
+        _multiSelectedRules.value = setOf()
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/RulesViewModel.kt
@@ -59,6 +59,10 @@ class RulesViewModel @Inject constructor(
         setDeleteConfirmationRequired(false)
     }
 
+    suspend fun deleteAllRules() {
+        rulesRepository.deleteAllRules()
+    }
+
     companion object {
         private const val TIMEOUT_MILLIS = 5000L
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,4 +78,6 @@
     <string name="delete_all_rules">Delete all rules</string>
     <string name="delete_selected">Delete selected</string>
     <string name="select_all">Select all</string>
+    <string name="delete_selected_rules">Delete selected rules</string>
+    <string name="delete_selected_rules_description">Are you sure you want to delete the selected rules? This action can\'t be undone.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,15 +17,19 @@
 
     <!-- mt = mutation type -->
     <string name="mt_domain_name">Change domain name</string>
+    <string name="mt_domain_name_present_simple_tense">Changes the given domain name</string>
     <string name="mt_domain_name_desc">Modify the domain name and keep the rest of the link the same</string>
 
     <string name="mt_url_params_all">Remove all URL parameters</string>
+    <string name="mt_url_params_all_present_simple_tense">Removes all URL parameters</string>
     <string name="mt_url_params_all_desc">Strip every parameter out of the link</string>
 
     <string name="mt_url_params_specific">Remove specific URL parameters</string>
+    <string name="mt_url_params_specific_present_simple_tense">Removes specific URL parameters</string>
     <string name="mt_url_params_specific_desc">Only remove certain parameters from the link</string>
 
     <string name="mt_domain_name_and_url_params_all">Change domain name and remove all URL parameters</string>
+    <string name="mt_domain_name_and_url_params_all_present_simple_tense">Changes the given domain name and removes all URL parameters</string>
     <string name="mt_domain_name_and_url_params_all_desc">Modify the domain name and strip every parameter out of the link</string>
 
     <string name="empty" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,6 @@
     <string name="content_desc_backup_off">Backup off</string>
     <string name="content_desc_backup_on">Backup on</string>
     <string name="content_desc_last_modified">Last modified</string>
+    <string name="keep_content">Keep content</string>
+    <string name="keep_content_supporting_text">Retain the original shared content</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,4 +75,7 @@
     <string name="content_desc_last_modified">Last modified</string>
     <string name="keep_content">Keep content</string>
     <string name="keep_content_supporting_text">Retain the original shared content</string>
+    <string name="delete_all_rules">Delete all rules</string>
+    <string name="delete_selected">Delete selected</string>
+    <string name="select_all">Select all</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,4 +60,13 @@
     <string name="search_rules">Search rules</string>
     <string name="account_and_settings">Account and settings</string>
     <string name="no_rules_added_yet">No rules added yet</string>
+    <string name="backed_up">Backed up</string>
+    <string name="not_backed_up">Not backed up</string>
+    <string name="collapse_details">Collapse details</string>
+    <string name="expand_details">Expand details</string>
+    <string name="content_desc_rule_name">Rule name</string>
+    <string name="content_desc_domain_name">Domain name</string>
+    <string name="content_desc_backup_off">Backup off</string>
+    <string name="content_desc_backup_on">Backup on</string>
+    <string name="content_desc_last_modified">Last modified</string>
 </resources>


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

- Refines the UI of RuleDetailsScreen
- Fixes #56 



## 🧑‍💻 Implementation/changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
### RuleDetailsScreen UI
- Display general rule details on RuleDetailsScreen (properties of BaseMutationModel that are useful to the user) in an expandable list. This list will be expanded by default, whereas any others added in the future will have to be expanded by the user.

### RulesScreen rule items multi-selection
- Enable selection of rule items on RulesScreen via the standard Android UX pattern of long-pressing an item to enter selection mode and tapping any other desired items to add them to the selection. When in selection mode, the top app bar changes to display the number of selected items, as well as the following actions:
  - A "select all" action, for ease of deleting everything.
  - A "delete" action, which displays a confirmation dialog (`AlertDialog`), in which clicking the confirmation button ("Delete") deletes the selected rules.
- MainViewModel acts as the SSOT for the state of currently selected rules.
  - The instance of this VM will be alive as long as MainActivity is launched/running, as opposed to the typical approach of a screen-scoped VM, or the less common approach of a VM shared between destinations of a nested navigation graph (see [`NavBackStackEntry.sharedViewModel`](https://github.com/suvanl/FixMyLinks/blob/ui-refine/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt#L397)).
  - This 'wider'-scoped VM is necessary because the currently selected rules state needs to be consumed by the top app bar, which is declared in the `topBar` argument of the Scaffold in the app-level composable (`FixMyLinksApp`), and subsequently the NavHost (`FmlNavHost`); both of which are ancestors of any screen-level composable. 

## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
### RuleDetailsScreen
- Add tests for asserting that the correct rule type description (in present simple tense) is displayed in RuleDetailsScreen.
- Test whether the delete confirmation dialog is shown when required.

### RulesScreen
- Add tests for list items:
  - Assert that rules in the set passed as the `selectedItems` argument are (semantically) selected in the UI.
    - In the future, test(s) for asserting the visual properties of a selected item (background colour, etc) will be added. 
  - Assert that each rule has a shape displayed beside it (represents the rule type in an abstract visual manner).
  - Assert that the correct shape is displayed (since each rule type is associated with a shape).

## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A