### PR TITLE
🐛 UI bug fixes and accessibility improvements in RulesScreen (via RulesListItem)

### DIFF
--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -67,7 +67,7 @@ class RulesScreenTest {
                 .assertIsDisplayed()
 
             composeTestRule
-                .onNodeWithText(rule.name)
+                .onNodeWithText(rule.name, useUnmergedTree = true)
                 .assertExists()
                 .assertIsDisplayed()
         }
@@ -140,37 +140,37 @@ class RulesScreenTest {
         fakeRules.forEach { rule ->
             when (rule.mutationType) {
                 MutationType.DOMAIN_NAME -> {
-                    composeTestRule.onNodeWithContentDescription("Square")
+                    composeTestRule.onNodeWithContentDescription("Square", useUnmergedTree = true)
                         .assertExists()
                         .assertIsDisplayed()
                 }
 
                 MutationType.URL_PARAMS_ALL -> {
-                    composeTestRule.onNodeWithContentDescription("Scallop")
+                    composeTestRule.onNodeWithContentDescription("Scallop", useUnmergedTree = true)
                         .assertExists()
                         .assertIsDisplayed()
                 }
 
                 MutationType.URL_PARAMS_SPECIFIC -> {
-                    composeTestRule.onNodeWithContentDescription("Delta")
+                    composeTestRule.onNodeWithContentDescription("Delta", useUnmergedTree = true)
                         .assertExists()
                         .assertIsDisplayed()
                 }
 
                 MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
-                    composeTestRule.onNodeWithContentDescription("Clover")
+                    composeTestRule.onNodeWithContentDescription("Clover", useUnmergedTree = true)
                         .assertExists()
                         .assertIsDisplayed()
                 }
 
                 MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> {
-                    composeTestRule.onNodeWithContentDescription("Eight-point star")
+                    composeTestRule.onNodeWithContentDescription("Eight-point star", useUnmergedTree = true)
                         .assertExists()
                         .assertIsDisplayed()
                 }
 
                 MutationType.FALLBACK -> {
-                    composeTestRule.onNodeWithContentDescription("Circle")
+                    composeTestRule.onNodeWithContentDescription("Circle", useUnmergedTree = true)
                         .assertExists()
                         .assertIsDisplayed()
                 }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/repository/CustomRulesRepository.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/repository/CustomRulesRepository.kt
@@ -96,7 +96,7 @@ class CustomRulesRepository @Inject constructor(
     override fun getRuleByBaseId(
         baseRuleId: Long,
         ruleType: MutationType
-    ): Flow<BaseMutationModel> {
+    ): Flow<BaseMutationModel?> {
         localDatabase.apply {
             return when (ruleType) {
                 MutationType.URL_PARAMS_ALL -> {
@@ -287,8 +287,10 @@ class CustomRulesRepository @Inject constructor(
      *  DAO query function.
      * @return A domain model ([BaseMutationModel]-derived objects).
      */
-    private fun <TValue> Flow<Map<BaseRule, TValue>>.toDomainModelFlow(): Flow<BaseMutationModel> {
+    private fun <TValue> Flow<Map<BaseRule, TValue>>.toDomainModelFlow(): Flow<BaseMutationModel?> {
         return this.map { multimap ->
+            if (multimap.isEmpty()) return@map null
+
             val (baseRule, genericRule) = multimap.entries.first().toPair()
             mapEntityToDomainModel(baseRule, genericRule)
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/data/repository/RulesRepository.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/repository/RulesRepository.kt
@@ -13,7 +13,7 @@ interface RulesRepository {
 
     suspend fun deleteByBaseRuleId(baseRuleId: Long)
 
-    fun getRuleByBaseId(baseRuleId: Long, ruleType: MutationType): Flow<BaseMutationModel>
+    fun getRuleByBaseId(baseRuleId: Long, ruleType: MutationType): Flow<BaseMutationModel?>
 
     fun getAllRules(): Flow<List<BaseMutationModel>>
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
@@ -25,6 +25,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -34,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.graphics.shapes.Morph
+import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationInfo
@@ -44,6 +48,7 @@ import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 import com.suvanl.fixmylinks.ui.util.PreviewData
 import com.suvanl.fixmylinks.ui.util.getRoundedPolygonForRule
+import com.suvanl.fixmylinks.ui.util.getRuleTypeInPresentSimpleTense
 
 @Composable
 fun RulesListItem(
@@ -52,6 +57,9 @@ fun RulesListItem(
     modifier: Modifier = Modifier,
 ) {
     val (polygon, polygonSemantics) = getRoundedPolygonForRule(rule.mutationType)
+    val rulePst = getRuleTypeInPresentSimpleTense(ruleType = rule.mutationType)
+    val parentContentDescription =
+        stringResource(R.string.cd_rules_list_item, rule.name, rule.triggerDomain, rulePst.asString())
 
     val shapeMorphProgress = remember { Animatable(0f) }
     val morphed by remember {
@@ -73,9 +81,10 @@ fun RulesListItem(
             }
         ),
         shape = RoundedCornerShape(20.dp),
-        modifier = modifier.semantics {
+        modifier = modifier.semantics(mergeDescendants = true) {
             selected = isSelected
             testTag = "Rules List Item ${rule.baseRuleId}"
+            contentDescription = parentContentDescription
         }
     ) {
         ListItem(
@@ -129,7 +138,9 @@ fun RulesListItem(
             colors = ListItemDefaults.colors(
                 containerColor = Color.Transparent
             ),
-            modifier = Modifier.padding(4.dp)
+            modifier = Modifier
+                .padding(4.dp)
+                .clearAndSetSemantics {}
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
@@ -90,7 +90,7 @@ fun enterNavigationTransition(
     val initialDestinationRoute = getBaseRoute(transitionScope.initialState.destination.route)
     val targetDestinationRoute = getBaseRoute(transitionScope.targetState.destination.route)
 
-    // Inverse of isNavigatingFromTopLevelDestinationToFlow
+    // If we're navigating from a destination that's part of a user flow back to a top-level destination
     val isNavigatingFromFlowToTopLevelDestination =
         userFlowScreens.any { it.route == initialDestinationRoute }
                 && topLevelScreensWithFab.any { it.route == targetDestinationRoute }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/NavigationTransition.kt
@@ -33,7 +33,7 @@ fun exitNavigationTransition(
 
     // Whether we're navigating from a screen within a user flow to a top-level screen
     // that has a FAB
-    val isNavigatingFromFlowToTopLevelScreen =
+    val isNavigatingFromFlowToTopLevelDestination =
         userFlowScreens.any { it.route == initialDestinationRoute }
                 && topLevelScreensWithFab.any { it.route == targetDestinationRoute }
 
@@ -41,7 +41,7 @@ fun exitNavigationTransition(
     // a screen that this flow could've been started from
     return if (
         userFlowScreens.any { it.route == targetDestinationRoute }
-        || isNavigatingFromFlowToTopLevelScreen
+        || isNavigatingFromFlowToTopLevelDestination
     ) {
         // Perform slide out animation when navigating from an initial state of a screen that is
         // part of the "add new rule" flow, and the target destination is a screen that this flow
@@ -90,19 +90,16 @@ fun enterNavigationTransition(
     val initialDestinationRoute = getBaseRoute(transitionScope.initialState.destination.route)
     val targetDestinationRoute = getBaseRoute(transitionScope.targetState.destination.route)
 
-    // If we're navigating from a destination with the FAB to a destination in a user flow
-    // or if we're performing intra-flow navigation, use the slide animation
-    val isNavigatingFromTopLevelDestinationToFlow =
-        topLevelScreensWithFab.any { it.route == initialDestinationRoute }
-                && userFlowScreens.any { it.route == targetDestinationRoute }
-
     // Inverse of isNavigatingFromTopLevelDestinationToFlow
     val isNavigatingFromFlowToTopLevelDestination =
         userFlowScreens.any { it.route == initialDestinationRoute }
                 && topLevelScreensWithFab.any { it.route == targetDestinationRoute }
 
+    // If the target destination is part of a user flow, or if we're navigating out of a flow
+    // (back to a top-level destination)
     return if (
-        isNavigatingFromTopLevelDestinationToFlow || isNavigatingFromFlowToTopLevelDestination
+        userFlowScreens.any { it.route == targetDestinationRoute }
+        || isNavigatingFromFlowToTopLevelDestination
     ) {
         transitionScope.slideIntoContainer(
             towards = when (transitionMode) {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -56,13 +56,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.suvanl.fixmylinks.R
-import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
 import com.suvanl.fixmylinks.ui.components.list.RuleDetailsList
 import com.suvanl.fixmylinks.ui.components.list.RuleDetailsListItemState
 import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 import com.suvanl.fixmylinks.ui.util.PreviewData
+import com.suvanl.fixmylinks.ui.util.getRuleTypeInPresentSimpleTense
 import com.suvanl.fixmylinks.ui.util.getShapeForRule
 
 /**
@@ -127,7 +127,7 @@ fun RuleDetailsScreen(
             Column(
                 modifier = Modifier.weight(1F)
             ) {
-                val ruleTypeInfo = getRuleTypeInPresentSimpleTense(ruleType = rule.mutationType)
+                val ruleTypeInfo = getRuleTypeInPresentSimpleTense(rule.mutationType).asString()
                 var lineCount by remember { mutableIntStateOf(0) }
 
                 if (lineCount < 2) {
@@ -333,33 +333,6 @@ private fun DeleteConfirmationDialog(
         onDismissRequest = onDismissRequest,
         modifier = modifier.semantics { testTag = "Delete Confirmation Dialog" }
     )
-}
-
-@Composable
-private fun getRuleTypeInPresentSimpleTense(ruleType: MutationType) = when (ruleType) {
-    MutationType.DOMAIN_NAME -> {
-        stringResource(id = R.string.mt_domain_name_present_simple_tense)
-    }
-
-    MutationType.URL_PARAMS_ALL -> {
-        stringResource(id = R.string.mt_url_params_all_present_simple_tense)
-    }
-
-    MutationType.URL_PARAMS_SPECIFIC -> {
-        stringResource(id = R.string.mt_url_params_specific_present_simple_tense)
-    }
-
-    MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
-        stringResource(id = R.string.mt_domain_name_and_url_params_all_present_simple_tense)
-    }
-
-    MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> {
-        TODO("Not user-selectable yet")
-    }
-
-    MutationType.FALLBACK -> {
-        throw IllegalArgumentException("MutationType.FALLBACK should not be user-selectable")
-    }
 }
 
 @Preview(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -198,7 +198,7 @@ fun AddRuleScreenBody(
             comingSoon = true,
         ),
         SwitchListItemState(
-            headlineText = "Keep content",
+            headlineText = stringResource(id = R.string.backup_to_cloud),
             supportingText = stringResource(R.string.backup_to_cloud_supporting_text),
             leadingIcon = Icons.Outlined.Backup,
             isSwitchChecked = ruleOptions.backupEnabled,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/UiUtils.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/UiUtils.kt
@@ -4,8 +4,10 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.contentDescription
 import androidx.graphics.shapes.RoundedPolygon
+import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
 import com.suvanl.fixmylinks.ui.graphics.CustomShapes
+import com.suvanl.fixmylinks.util.UiText
 
 /**
  * A [Shape] with optional semantics properties for accessibility/testing purposes.
@@ -78,5 +80,35 @@ fun getRoundedPolygonForRule(ruleType: MutationType): UiRoundedPolygon = when (r
 
     MutationType.FALLBACK -> {
         UiRoundedPolygon(CustomShapes.CirclePolygon) { contentDescription = "Circle" }
+    }
+}
+
+/**
+ * Returns [UiText] representing the humanized form of the given [MutationType] in
+ * present simple tense.
+ */
+fun getRuleTypeInPresentSimpleTense(ruleType: MutationType) = when (ruleType) {
+    MutationType.DOMAIN_NAME -> {
+        UiText.StringResource(R.string.mt_domain_name_present_simple_tense)
+    }
+
+    MutationType.URL_PARAMS_ALL -> {
+        UiText.StringResource(id = R.string.mt_url_params_all_present_simple_tense)
+    }
+
+    MutationType.URL_PARAMS_SPECIFIC -> {
+        UiText.StringResource(id = R.string.mt_url_params_specific_present_simple_tense)
+    }
+
+    MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL -> {
+        UiText.StringResource(id = R.string.mt_domain_name_and_url_params_all_present_simple_tense)
+    }
+
+    MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC -> {
+        TODO("Not user-selectable yet")
+    }
+
+    MutationType.FALLBACK -> {
+        UiText.StringResource(id = R.string.empty)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,4 +79,7 @@
     <string name="select_all">Select all</string>
     <string name="delete_selected_rules">Delete selected rules</string>
     <string name="delete_selected_rules_description">Are you sure you want to delete the selected rules? This action can\'t be undone.</string>
+
+    <!-- format: "{rule type} on {trigger domain}. {present simple tense rule desc}." -->
+    <string name="cd_rules_list_item">%1$s on %2$s. %3$s.</string>
 </resources>


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

Fixes mid- to high-severity UI bugs and improves the accessibility of RulesScreen by reducing the amount of user interaction required when using TalkBack.



## 🧑‍💻 Implementation/changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->

- Fix bug where deleting a rule via the TopAppBar on the RuleDetails destination would delete the rule, but cause the app to crash with a NoSuchElementException.
  - Prevent NSEE in `toDomainModelFlow()` extension function by checking by returning `null` early if the map is empty.
  
- Fix bug where incorrect EnterTransition would be used during intra-flow navigation (e.g., from SelectRuleTypeScreen to AddRuleTypeScreen).
  - Ensure `slideIntoContainer()` is used instead of `scaleIntoContainer()` in this condition.
  - Remove the check to determine whether the initial destination is part of `topLevelScreensWithFab` in the condition for using `slideIntoContainer()`, because the initial destination won't be a top-level destination in intra-flow navigation.

- Fix the wrong text being displayed for the "backup to cloud" option on AddRuleScreen.

- Improve accessibility of RulesScreen by reducing the number of swipes required to traverse the RulesList when using TalkBack.
  - RulesListItem: set the content description at the parent composable level and clear all semantics from child composables to prevent talkback highlighting the children of the parent composable (Card).
  - Extract `getRuleTypeInPresentSimpleTense` function out of RuleDetailsScreen as it is required for part of the content description in RulesListItem. It now exists within UiUtils.kt and is no longer a composable function as it returns `UiText.StringResource`.


## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
-  RulesScreenTest: set `useUnmergedTree` to true on finders when the rules state is not empty (i.e., when `EmptyRulesBody` is not going to be displayed).


## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A