### PR TITLE
Support wildcard subdomains in domain names (trigger, initial, and target)

### DIFF
--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleFormTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleFormTest.kt
@@ -1,0 +1,150 @@
+package com.suvanl.fixmylinks.ui.components.form
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.suvanl.fixmylinks.R
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class DomainNameRuleFormTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var addWildcardButtonContentDescription: String
+    private lateinit var initialDomainNameLabel: String
+    private lateinit var targetDomainNameLabel: String
+    private lateinit var ruleNameLabel: String
+
+    @Before
+    fun setup() {
+        composeTestRule.activity.apply {
+            addWildcardButtonContentDescription = getString(R.string.cd_add_wildcard_operator)
+            initialDomainNameLabel = getString(R.string.initial_domain_name)
+            targetDomainNameLabel = getString(R.string.target_domain_name)
+            ruleNameLabel = getString(R.string.rule_name)
+        }
+    }
+
+    private fun setDomainNameRuleForm(formState: DomainNameRuleFormState = DomainNameRuleFormState()) {
+        composeTestRule.setContent {
+            DomainNameRuleForm(
+                formState = formState,
+                showHints = true,
+                onRuleNameChange = {},
+                onInitialDomainNameChange = {},
+                onTargetDomainNameChange = {},
+                onClickAddInitialWildcard = {},
+                onClickAddTargetWildcard = {},
+            )
+        }
+    }
+
+    @Test
+    fun domainNameRuleForm_ruleNameField_isDisplayed() {
+        setDomainNameRuleForm()
+
+        composeTestRule
+            .onNodeWithText(ruleNameLabel)
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    // Assert that the "add wildcard operator" button is displayed on the "initial domain name" and
+    // "target domain name" fields in DomainNameRuleForm. No need to test this in the other forms
+    // (AllUrlParamsRuleForm and SpecificUrlParamsRuleForm), since these use the reusable
+    // DomainNameField composable, which already has tests to assert this (see DomainNameFieldTest).
+
+    @Test
+    fun domainNameRuleForm_displaysAddWildcardButton_inInitialDomainNameField_whenEmpty() {
+        setDomainNameRuleForm()
+
+        composeTestRule
+            .onNode(
+                matcher = hasContentDescription(addWildcardButtonContentDescription) and hasParent(
+                    hasText(initialDomainNameLabel)
+                )
+            )
+            .assertExists()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun domainNameRuleForm_displaysAddWildcardButton_inTargetDomainNameField_whenEmpty() {
+        setDomainNameRuleForm()
+
+        composeTestRule
+            .onNode(
+                matcher = hasContentDescription(addWildcardButtonContentDescription) and hasParent(
+                    hasText(targetDomainNameLabel)
+                )
+            )
+            .assertExists()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun domainNameRuleForm_displaysAddWildcardButton_inInitialDomainNameField_whenBlank() {
+        setDomainNameRuleForm(DomainNameRuleFormState(initialDomainName = "   "))
+
+        composeTestRule
+            .onNode(
+                matcher = hasContentDescription(addWildcardButtonContentDescription) and hasParent(
+                    hasText(initialDomainNameLabel)
+                )
+            )
+            .assertExists()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun domainNameRuleForm_displaysAddWildcardButton_inTargetDomainNameField_whenBlank() {
+        setDomainNameRuleForm(DomainNameRuleFormState(targetDomainName = "   "))
+
+        composeTestRule
+            .onNode(
+                matcher = hasContentDescription(addWildcardButtonContentDescription) and hasParent(
+                    hasText(targetDomainNameLabel)
+                )
+            )
+            .assertExists()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun domainNameRuleForm_doesNotDisplayAddWildcardButton_inInitialDomainNameField_whenNotBlank() {
+        setDomainNameRuleForm(DomainNameRuleFormState(initialDomainName = "a"))
+
+        composeTestRule
+            .onNode(
+                matcher = hasContentDescription(addWildcardButtonContentDescription) and hasParent(
+                    hasText(initialDomainNameLabel)
+                )
+            )
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun domainNameRuleForm_doesNotDisplayAddWildcardButton_inTargetDomainNameField_whenNotBlank() {
+        setDomainNameRuleForm(DomainNameRuleFormState(targetDomainName = "a"))
+
+        composeTestRule
+            .onNode(
+                matcher = hasContentDescription(addWildcardButtonContentDescription) and hasParent(
+                    hasText(targetDomainNameLabel)
+                )
+            )
+            .assertDoesNotExist()
+    }
+}

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameFieldTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameFieldTest.kt
@@ -3,8 +3,14 @@ package com.suvanl.fixmylinks.ui.components.form.common
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasImeAction
+import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.input.ImeAction
 import com.suvanl.fixmylinks.R
 import org.junit.Before
 import org.junit.Rule
@@ -65,5 +71,19 @@ class DomainNameFieldTest {
         composeTestRule
             .onNodeWithContentDescription(addWildcardButtonContentDescription)
             .assertDoesNotExist()
+    }
+
+    @Test
+    fun domainNameField_clickAddWildcardButton_focusesTextField() {
+        setDomainNameField()
+
+        composeTestRule
+            .onNodeWithContentDescription(addWildcardButtonContentDescription)
+            .assertExists()
+            .performClick()
+
+        composeTestRule
+            .onNode(hasImeAction(ImeAction.Next) and hasParent(isRoot()))
+            .assertIsFocused()
     }
 }

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameFieldTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameFieldTest.kt
@@ -1,0 +1,69 @@
+package com.suvanl.fixmylinks.ui.components.form.common
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import com.suvanl.fixmylinks.R
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class DomainNameFieldTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private lateinit var addWildcardButtonContentDescription: String
+
+    @Before
+    fun setup() {
+        addWildcardButtonContentDescription =
+            composeTestRule.activity.getString(R.string.cd_add_wildcard_operator)
+    }
+
+    private fun setDomainNameField(value: String = "") {
+        composeTestRule.setContent {
+            DomainNameField(
+                value = value,
+                errorMessage = null,
+                showHints = true,
+                isLastFieldInForm = false,
+                onValueChange = {},
+                onClickAddWildcard = {}
+            )
+        }
+    }
+
+    @Test
+    fun domainNameField_addWildcardButton_isDisplayed_whenValueIsEmpty() {
+        setDomainNameField()
+
+        composeTestRule
+            .onNodeWithContentDescription(addWildcardButtonContentDescription)
+            .assertExists()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun domainNameField_addWildcardButton_isDisplayed_whenValueIsBlank() {
+        setDomainNameField(value = "      ")
+
+        composeTestRule
+            .onNodeWithContentDescription(addWildcardButtonContentDescription)
+            .assertExists()
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun domainNameField_addWildcardButton_isNotDisplayed_whenValueIsNotBlank() {
+        setDomainNameField(value = "w")
+
+        composeTestRule
+            .onNodeWithContentDescription(addWildcardButtonContentDescription)
+            .assertDoesNotExist()
+    }
+}

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreenTest.kt
@@ -43,6 +43,7 @@ class AddRuleScreenTest {
                         onDomainNameChange = {},
                         onClickAddParam = {},
                         onClickDismissParam = {},
+                        onClickAddWildcard = {},
                     )
                 }
 
@@ -54,6 +55,8 @@ class AddRuleScreenTest {
                         onRuleNameChange = {},
                         onInitialDomainNameChange = {},
                         onTargetDomainNameChange = {},
+                        onClickAddInitialWildcard = {},
+                        onClickAddTargetWildcard = {},
                     )
                 }
                 MutationType.URL_PARAMS_ALL -> {
@@ -61,7 +64,8 @@ class AddRuleScreenTest {
                         showHints = true,
                         formState = AllUrlParamsRuleFormState(),
                         onRuleNameChange = {},
-                        onDomainNameChange = {}
+                        onDomainNameChange = {},
+                        onClickAddWildcard = {},
                     )
                 }
                 else -> {

--- a/app/src/main/java/com/suvanl/fixmylinks/MainActivity.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/MainActivity.kt
@@ -13,9 +13,8 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
         enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
 
         setContent {
             val windowSizeClass = calculateWindowSizeClass(activity = this)

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
@@ -75,6 +75,9 @@ class MutateUriUseCase @Inject constructor() {
         val allRules = BuiltInRules.all + customRules
         return allRules.find { rule ->
             if (rule.triggerDomain.startsWith("*.")) {
+                // Wildcard operator functionality: compare triggerDomain and URI.host without
+                // subdomain on both sides of the equality check.
+                // Note that URI.removeSubdomain("*") removes any subdomain that the URI.host may contain.
                 rule.triggerDomain.removePrefix("*.") == uri.removeSubdomain("*").host
             } else {
                 rule.triggerDomain == uri.host

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
@@ -73,6 +73,12 @@ class MutateUriUseCase @Inject constructor() {
      */
     private fun findRule(uri: URI, customRules: List<BaseMutationModel>): BaseMutationModel? {
         val allRules = BuiltInRules.all + customRules
-        return allRules.find { it.triggerDomain == uri.host }
+        return allRules.find { rule ->
+            if (rule.triggerDomain.startsWith("*.")) {
+                rule.triggerDomain.removePrefix("*.") == uri.removeSubdomain("*").host
+            } else {
+                rule.triggerDomain == uri.host
+            }
+        }
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutatedUri.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutatedUri.kt
@@ -2,11 +2,13 @@ package com.suvanl.fixmylinks.domain.mutation
 
 import java.net.URI
 
+// TODO: refactor with better, more scalable API design?
 data class MutatedUri(
     val scheme: String,
     val host: String,
     val path: String? = null,
-    val rawQuery: String? = null
+    val rawQuery: String? = null,
+    val fragment: String? = null,
 ) {
     /**
      * Builds a [java.net.URI] with the data provided in the [MutatedUri] primary constructor
@@ -20,7 +22,8 @@ data class MutatedUri(
 
         val pathStr = if (path.isNullOrEmpty()) "" else path
         val queryStr = if (rawQuery.isNullOrEmpty()) "" else "?$rawQuery"
+        val fragmentStr = if (fragment.isNullOrEmpty()) "" else "#$fragment"
 
-        return URI("$scheme://$host$pathStr$queryStr")
+        return URI("$scheme://$host$pathStr$queryStr$fragmentStr")
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/RemoveSpecificUrlParamsUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/RemoveSpecificUrlParamsUseCase.kt
@@ -8,7 +8,7 @@ class RemoveSpecificUrlParamsUseCase {
         paramsToRemove: List<String>,
         useWwwSubdomain: Boolean,
     ): URI {
-        if (uri.rawQuery == null || paramsToRemove.isEmpty()) return uri
+        if (uri.rawQuery.isNullOrBlank() || paramsToRemove.isEmpty()) return uri
         val queryString = uri.rawQuery
 
         val removeAllUrlParamsUseCase = RemoveAllUrlParamsUseCase()

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/RemoveSpecificUrlParamsUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/RemoveSpecificUrlParamsUseCase.kt
@@ -20,7 +20,7 @@ class RemoveSpecificUrlParamsUseCase {
             val paramName = queryString.split("=", limit = 2)[0]
 
             if (!paramsToRemove.contains(paramName)) {
-                return MutatedUri(
+                return UriBuilder(
                     scheme = uri.scheme,
                     host = if (useWwwSubdomain) "www.${uri.host}" else uri.host,
                     path = uri.path,
@@ -32,7 +32,7 @@ class RemoveSpecificUrlParamsUseCase {
             // query string (since it only had one parameter, and a parameter with this name exists
             // within the `paramsToRemove` List, meaning it should be removed).
             return removeAllUrlParamsUseCase(
-                uri = MutatedUri(
+                uri = UriBuilder(
                     scheme = uri.scheme,
                     host = if (useWwwSubdomain) "www.${uri.host}" else uri.host,
                     path = uri.path,
@@ -72,7 +72,7 @@ class RemoveSpecificUrlParamsUseCase {
 
         uri.apply {
             // Rebuild the URI with the newly mutated query string
-            return MutatedUri(
+            return UriBuilder(
                 scheme = scheme,
                 host = if (useWwwSubdomain) "www.$host" else host,
                 path = path,

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/ReplaceDomainNameUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/ReplaceDomainNameUseCase.kt
@@ -1,6 +1,7 @@
 package com.suvanl.fixmylinks.domain.mutation
 
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
+import com.suvanl.fixmylinks.domain.util.UriUtils.findSubdomain
 import java.net.URI
 
 class ReplaceDomainNameUseCase {
@@ -10,15 +11,29 @@ class ReplaceDomainNameUseCase {
         useWwwSubdomain: Boolean
     ): URI {
         uri.apply {
-            return MutatedUri(
-                scheme = scheme,
-                host = if (useWwwSubdomain) {
-                    "www.${mutationInfo.targetDomain}"
+            val hasWildcardSubdomain = mutationInfo.initialDomain.startsWith("*.")
+
+            val domain = if (hasWildcardSubdomain) {
+                val subdomain = findSubdomain()
+                if (!subdomain.isNullOrBlank() && mutationInfo.targetDomain.startsWith("*.")) {
+                    // Retain the subdomain present in `uri` if the targetDomain starts with the
+                    // wildcard operator (*.)
+                    "${subdomain}.${mutationInfo.targetDomain.removePrefix("*.")}"
                 } else {
                     mutationInfo.targetDomain
-                },
+                }
+            } else if (useWwwSubdomain) {
+                "www.${mutationInfo.targetDomain}"
+            } else {
+                mutationInfo.targetDomain
+            }
+
+            return MutatedUri(
+                scheme = scheme,
+                host = domain,
                 path = path,
-                rawQuery = rawQuery
+                rawQuery = rawQuery,
+                fragment = fragment,
             ).build()
         }
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/ReplaceDomainNameUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/ReplaceDomainNameUseCase.kt
@@ -13,6 +13,11 @@ class ReplaceDomainNameUseCase {
         uri.apply {
             val hasWildcardSubdomain = mutationInfo.initialDomain.startsWith("*.")
 
+            // in future: use form validation to prevent this situation from occurring (by only
+            // allowing targetDomain to contain wildcard if initialDomain contains it too)?
+            val onlyTargetHasWildcardSubdomain =
+                mutationInfo.targetDomain.startsWith("*.") && !hasWildcardSubdomain
+
             val domain = if (hasWildcardSubdomain) {
                 val subdomain = findSubdomain()
                 if (!subdomain.isNullOrBlank() && mutationInfo.targetDomain.startsWith("*.")) {
@@ -21,6 +26,12 @@ class ReplaceDomainNameUseCase {
                     "${subdomain}.${mutationInfo.targetDomain.removePrefix("*.")}"
                 } else {
                     mutationInfo.targetDomain
+                }
+            } else if (onlyTargetHasWildcardSubdomain) {
+                if (useWwwSubdomain) {
+                    "www.${mutationInfo.targetDomain.removePrefix("*.")}"
+                } else {
+                    mutationInfo.targetDomain.removePrefix("*.")
                 }
             } else if (useWwwSubdomain) {
                 "www.${mutationInfo.targetDomain}"

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/ReplaceDomainNameUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/ReplaceDomainNameUseCase.kt
@@ -28,7 +28,7 @@ class ReplaceDomainNameUseCase {
                 mutationInfo.targetDomain
             }
 
-            return MutatedUri(
+            return UriBuilder(
                 scheme = scheme,
                 host = domain,
                 path = path,

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/UriBuilder.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/UriBuilder.kt
@@ -2,8 +2,7 @@ package com.suvanl.fixmylinks.domain.mutation
 
 import java.net.URI
 
-// TODO: refactor with better, more scalable API design?
-data class MutatedUri(
+data class UriBuilder(
     val scheme: String,
     val host: String,
     val path: String? = null,
@@ -11,7 +10,7 @@ data class MutatedUri(
     val fragment: String? = null,
 ) {
     /**
-     * Builds a [java.net.URI] with the data provided in the [MutatedUri] primary constructor
+     * Builds a [java.net.URI] with the data provided in the [UriBuilder] primary constructor
      */
     fun build(): URI {
         if (scheme.isEmpty()) throw IllegalArgumentException("URI scheme must be provided")

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
@@ -1,6 +1,6 @@
 package com.suvanl.fixmylinks.domain.util
 
-import com.suvanl.fixmylinks.domain.mutation.MutatedUri
+import com.suvanl.fixmylinks.domain.mutation.UriBuilder
 import java.net.URI
 
 object UriUtils {
@@ -20,7 +20,7 @@ object UriUtils {
         val hostWithoutSubdomain = host.removePrefix("${removableSubdomain}.")
         val hasUrlParams = !rawQuery.isNullOrEmpty()
 
-        return MutatedUri(
+        return UriBuilder(
             scheme = scheme,
             host = hostWithoutSubdomain,
             path = path,

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
@@ -35,7 +35,7 @@ object UriUtils {
      * Looks for a subdomain in the `URI.host` and if one or more exists, returns the first one.
      * Returns `null` if the `URI.host` doesn't appear to contain a subdomain.
      */
-    private fun URI.findSubdomain(): String? {
+    fun URI.findSubdomain(): String? {
         if (host.isNullOrBlank()) return null
 
         val parts = host.split(".")

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/util/UriUtils.kt
@@ -7,11 +7,17 @@ object UriUtils {
 
     /**
      * Removes a leading subdomain from a [URI]
-     * @param subdomain The subdomain to remove from the [URI]
+     * @param subdomain The subdomain to remove from the [URI]. If the given subdomain is a wildcard
+     *  operator (*), the subdomain to remove will be the first subdomain found in the `URI.host` string.
      * @return [URI] without the [subdomain]
      */
     fun URI.removeSubdomain(subdomain: String): URI {
-        val hostWithoutSubdomain = host.removePrefix("${subdomain}.")
+        var removableSubdomain = subdomain
+        if (subdomain == "*") {
+            removableSubdomain = this.subdomain ?: subdomain
+        }
+
+        val hostWithoutSubdomain = host.removePrefix("${removableSubdomain}.")
         val hasUrlParams = !rawQuery.isNullOrEmpty()
 
         return MutatedUri(
@@ -20,5 +26,19 @@ object UriUtils {
             path = path,
             rawQuery = if (hasUrlParams) rawQuery else null
         ).build()
+    }
+
+    private val URI.subdomain: String?
+        get() = findSubdomain()
+
+    /**
+     * Looks for a subdomain in the `URI.host` and if one or more exists, returns the first one.
+     * Returns `null` if the `URI.host` doesn't appear to contain a subdomain.
+     */
+    private fun URI.findSubdomain(): String? {
+        if (host.isNullOrBlank()) return null
+
+        val parts = host.split(".")
+        return if (parts.size >= 3) parts[0] else null
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/animation/TransitionDefaults.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/animation/TransitionDefaults.kt
@@ -4,6 +4,10 @@ import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 
 object TransitionDefaults {
     val supportingTextEnterTransition = fadeIn() + expandVertically(
@@ -12,4 +16,6 @@ object TransitionDefaults {
             stiffness = Spring.StiffnessLow
         )
     )
+
+    val errorMessageTransition = slideInVertically() togetherWith slideOutVertically() + fadeOut()
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/button/AddWildcardButton.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/button/AddWildcardButton.kt
@@ -1,0 +1,65 @@
+package com.suvanl.fixmylinks.ui.components.button
+
+import android.content.res.Configuration
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+
+@Composable
+fun AddWildcardButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val buttonContentDescription = stringResource(id = R.string.cd_add_wildcard_operator)
+    FilledTonalIconButton(
+        onClick = onClick,
+        modifier = modifier.semantics { contentDescription = buttonContentDescription }
+    ) {
+        Text(text = "*.", fontWeight = FontWeight.ExtraBold)
+    }
+}
+
+/**
+ * Variant of [AddWildcardButton] with animated visibility.
+ * @param visible Defines whether the button should be visible.
+ * @param onClick Called when the button is clicked.
+ */
+@Composable
+fun AnimatedAddWildcardButton(
+    visible: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = scaleIn() + fadeIn(),
+        exit = scaleOut() + fadeOut(),
+    ) {
+        AddWildcardButton(onClick = onClick, modifier = modifier)
+    }
+}
+
+@Preview
+@Preview(
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun AddWildcardButtonPreview() {
+    PreviewContainer {
+        AddWildcardButton(onClick = {})
+    }
+}

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/AllUrlParamsRuleForm.kt
@@ -29,6 +29,7 @@ fun AllUrlParamsRuleForm(
     showHints: Boolean,
     onRuleNameChange: (String) -> Unit,
     onDomainNameChange: (String) -> Unit,
+    onClickAddWildcard: () -> Unit,
     modifier: Modifier = Modifier,
     interFieldSpacing: Dp = FormDefaults.InterFieldSpacing,
 ) {
@@ -51,6 +52,7 @@ fun AllUrlParamsRuleForm(
             errorMessage = formState.domainNameError?.asString(),
             showHints = showHints,
             onValueChange = onDomainNameChange,
+            onClickAddWildcard = onClickAddWildcard,
             isLastFieldInForm = true,
             modifier = Modifier.fillMaxWidth()
         )
@@ -66,11 +68,12 @@ fun AllUrlParamsRuleForm(
 private fun AllUrlParamsRuleFormPreview() {
     PreviewContainer {
         AllUrlParamsRuleForm(
+            formState = AllUrlParamsRuleFormState(),
             showHints = true,
             interFieldSpacing = 16.dp,
             onRuleNameChange = {},
             onDomainNameChange = {},
-            formState = AllUrlParamsRuleFormState(),
+            onClickAddWildcard = {},
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -1,6 +1,7 @@
 package com.suvanl.fixmylinks.ui.components.form
 
 import android.content.res.Configuration
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -72,8 +73,14 @@ fun DomainNameRuleForm(
             supportingText = {
                 Column {
                     // Error message
-                    if (formState.initialDomainNameError != null) {
-                        FormFieldErrorMessage(text = formState.initialDomainNameError.asString())
+                    AnimatedContent(
+                        targetState = formState.initialDomainNameError,
+                        transitionSpec = { TransitionDefaults.errorMessageTransition },
+                        label = "form field error message"
+                    ) { errorMessage ->
+                        if (errorMessage != null) {
+                            FormFieldErrorMessage(text = errorMessage.asString())
+                        }
                     }
 
                     // Hint text
@@ -111,8 +118,14 @@ fun DomainNameRuleForm(
             },
             supportingText = {
                 Column {
-                    if (formState.targetDomainNameError != null) {
-                        FormFieldErrorMessage(text = formState.targetDomainNameError.asString())
+                    AnimatedContent(
+                        targetState = formState.targetDomainNameError,
+                        transitionSpec = { TransitionDefaults.errorMessageTransition },
+                        label = "form field error message"
+                    ) { errorMessage ->
+                        if (errorMessage != null) {
+                            FormFieldErrorMessage(text = errorMessage.asString())
+                        }
                     }
 
                     AnimatedVisibility(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -14,7 +14,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -52,6 +55,9 @@ fun DomainNameRuleForm(
     modifier: Modifier = Modifier,
     interFieldSpacing: Dp = FormDefaults.InterFieldSpacing,
 ) {
+    val initialDomainFocusRequester = remember { FocusRequester() }
+    val targetDomainFocusRequester = remember { FocusRequester() }
+
     Column(
         modifier = modifier
             .semantics { testTag = "DomainNameRuleForm" }
@@ -104,7 +110,10 @@ fun DomainNameRuleForm(
             trailingIcon = {
                 AnimatedAddWildcardButton(
                     visible = formState.initialDomainName.isBlank(),
-                    onClick = onClickAddInitialWildcard
+                    onClick = {
+                        initialDomainFocusRequester.requestFocus()
+                        onClickAddInitialWildcard()
+                    }
                 )
             },
             keyboardOptions = KeyboardOptions(
@@ -112,7 +121,9 @@ fun DomainNameRuleForm(
                 imeAction = ImeAction.Next
             ),
             isError = formState.initialDomainNameError != null,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(initialDomainFocusRequester)
         )
 
         Spacer(modifier = Modifier.height(interFieldSpacing))
@@ -154,7 +165,10 @@ fun DomainNameRuleForm(
             trailingIcon = {
                 AnimatedAddWildcardButton(
                     visible = formState.targetDomainName.isBlank(),
-                    onClick = onClickAddTargetWildcard
+                    onClick = {
+                        targetDomainFocusRequester.requestFocus()
+                        onClickAddTargetWildcard()
+                    }
                 )
             },
             keyboardOptions = KeyboardOptions(
@@ -162,7 +176,9 @@ fun DomainNameRuleForm(
                 imeAction = ImeAction.Done
             ),
             isError = formState.targetDomainNameError != null,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(targetDomainFocusRequester)
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/DomainNameRuleForm.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.animation.TransitionDefaults
+import com.suvanl.fixmylinks.ui.components.button.AnimatedAddWildcardButton
 import com.suvanl.fixmylinks.ui.components.form.common.FormFieldErrorMessage
 import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
@@ -46,6 +47,8 @@ fun DomainNameRuleForm(
     onRuleNameChange: (String) -> Unit,
     onInitialDomainNameChange: (String) -> Unit,
     onTargetDomainNameChange: (String) -> Unit,
+    onClickAddInitialWildcard: () -> Unit,
+    onClickAddTargetWildcard: () -> Unit,
     modifier: Modifier = Modifier,
     interFieldSpacing: Dp = FormDefaults.InterFieldSpacing,
 ) {
@@ -98,6 +101,12 @@ fun DomainNameRuleForm(
                     contentDescription = null
                 )
             },
+            trailingIcon = {
+                AnimatedAddWildcardButton(
+                    visible = formState.initialDomainName.isBlank(),
+                    onClick = onClickAddInitialWildcard
+                )
+            },
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Uri,
                 imeAction = ImeAction.Next
@@ -142,6 +151,12 @@ fun DomainNameRuleForm(
                     contentDescription = null
                 )
             },
+            trailingIcon = {
+                AnimatedAddWildcardButton(
+                    visible = formState.targetDomainName.isBlank(),
+                    onClick = onClickAddTargetWildcard
+                )
+            },
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Uri,
                 imeAction = ImeAction.Done
@@ -166,6 +181,8 @@ private fun DomainNameRuleFormPreview() {
             onRuleNameChange = {},
             onInitialDomainNameChange = {},
             onTargetDomainNameChange = {},
+            onClickAddInitialWildcard = {},
+            onClickAddTargetWildcard = {},
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
@@ -1,6 +1,7 @@
 package com.suvanl.fixmylinks.ui.components.form
 
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
@@ -34,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.R
+import com.suvanl.fixmylinks.ui.animation.TransitionDefaults
 import com.suvanl.fixmylinks.ui.components.form.common.DomainNameField
 import com.suvanl.fixmylinks.ui.components.form.common.FormFieldErrorMessage
 import com.suvanl.fixmylinks.ui.components.form.common.RuleNameField
@@ -106,10 +108,14 @@ fun SpecificUrlParamsRuleForm(
         }
 
         // Error message
-        if (formState.addedParamNamesError != null) {
-            FormFieldErrorMessage(
-                text = formState.addedParamNamesError.asString()
-            )
+        AnimatedContent(
+            targetState = formState.addedParamNamesError,
+            transitionSpec = { TransitionDefaults.errorMessageTransition },
+            label = "removable parameter list error message"
+        ) { errorMessage ->
+            if (errorMessage != null) {
+                FormFieldErrorMessage(text = errorMessage.asString())
+            }
         }
 
         ParamsChipGroup(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/SpecificUrlParamsRuleForm.kt
@@ -57,6 +57,7 @@ fun SpecificUrlParamsRuleForm(
     formState: SpecificUrlParamsRuleFormState,
     onRuleNameChange: (String) -> Unit,
     onDomainNameChange: (String) -> Unit,
+    onClickAddWildcard: () -> Unit,
     onClickAddParam: () -> Unit,
     onClickDismissParam: (Int) -> Unit,
     modifier: Modifier = Modifier,
@@ -81,6 +82,7 @@ fun SpecificUrlParamsRuleForm(
             errorMessage = formState.domainNameError?.asString(),
             showHints = showHints,
             onValueChange = onDomainNameChange,
+            onClickAddWildcard = onClickAddWildcard,
             isLastFieldInForm = true,
             modifier = Modifier.fillMaxWidth()
         )
@@ -178,6 +180,7 @@ private fun SpecificUrlParamsRuleFormPreview() {
             onDomainNameChange = {},
             onClickAddParam = {},
             onClickDismissParam = {},
+            onClickAddWildcard = {},
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.animation.TransitionDefaults
+import com.suvanl.fixmylinks.ui.components.button.AnimatedAddWildcardButton
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 
 @Composable
@@ -27,11 +28,12 @@ fun DomainNameField(
     showHints: Boolean,
     isLastFieldInForm: Boolean,
     onValueChange: (String) -> Unit,
+    onClickAddWildcard: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     OutlinedTextField(
         value = value,
-        onValueChange = onValueChange,
+        onValueChange = { onValueChange(it.trim()) },
         singleLine = true,
         label = {
             Text(text = stringResource(id = R.string.domain_name))
@@ -63,6 +65,12 @@ fun DomainNameField(
                 contentDescription = null
             )
         },
+        trailingIcon = {
+            AnimatedAddWildcardButton(
+                visible = value.isBlank(),
+                onClick = onClickAddWildcard
+            )
+        },
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Uri,
             imeAction = if (!isLastFieldInForm) ImeAction.Next else ImeAction.Done
@@ -85,6 +93,7 @@ private fun DomainNameFieldPreview() {
             showHints = true,
             isLastFieldInForm = false,
             onValueChange = {},
+            onClickAddWildcard = {},
         )
     }
 }
@@ -103,6 +112,7 @@ private fun DomainNameFieldWithErrorPreview() {
             showHints = true,
             isLastFieldInForm = false,
             onValueChange = {},
+            onClickAddWildcard = {},
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
@@ -11,7 +11,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -31,6 +34,8 @@ fun DomainNameField(
     onClickAddWildcard: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val focusRequester = remember { FocusRequester() }
+
     OutlinedTextField(
         value = value,
         onValueChange = { onValueChange(it.trim()) },
@@ -68,14 +73,17 @@ fun DomainNameField(
         trailingIcon = {
             AnimatedAddWildcardButton(
                 visible = value.isBlank(),
-                onClick = onClickAddWildcard
+                onClick = {
+                    focusRequester.requestFocus()
+                    onClickAddWildcard()
+                }
             )
         },
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Uri,
             imeAction = if (!isLastFieldInForm) ImeAction.Next else ImeAction.Done
         ),
-        modifier = modifier
+        modifier = modifier.focusRequester(focusRequester)
     )
 }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/form/common/DomainNameField.kt
@@ -1,5 +1,7 @@
 package com.suvanl.fixmylinks.ui.components.form.common
 
+import android.content.res.Configuration
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.KeyboardOptions
@@ -13,8 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.ui.animation.TransitionDefaults
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
 
 @Composable
 fun DomainNameField(
@@ -35,8 +39,14 @@ fun DomainNameField(
         isError = errorMessage != null,
         supportingText = {
             Column {
-                if (errorMessage != null) {
-                    FormFieldErrorMessage(text = errorMessage)
+                AnimatedContent(
+                    targetState = errorMessage,
+                    transitionSpec = { TransitionDefaults.errorMessageTransition },
+                    label = "form field error message"
+                ) { errorMessage ->
+                    if (errorMessage != null) {
+                        FormFieldErrorMessage(text = errorMessage)
+                    }
                 }
 
                 AnimatedVisibility(
@@ -59,4 +69,40 @@ fun DomainNameField(
         ),
         modifier = modifier
     )
+}
+
+@Preview
+@Preview(
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun DomainNameFieldPreview() {
+    PreviewContainer {
+        DomainNameField(
+            value = "",
+            errorMessage = null,
+            showHints = true,
+            isLastFieldInForm = false,
+            onValueChange = {},
+        )
+    }
+}
+
+@Preview
+@Preview(
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+@Composable
+private fun DomainNameFieldWithErrorPreview() {
+    PreviewContainer {
+        DomainNameField(
+            value = "Some invalid input",
+            errorMessage = "Error: error message",
+            showHints = true,
+            isLastFieldInForm = false,
+            onValueChange = {},
+        )
+    }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -116,6 +116,8 @@ fun AddRuleScreen(
                     onRuleNameChange = viewModel::setRuleName,
                     onInitialDomainNameChange = viewModel::setInitialDomainName,
                     onTargetDomainNameChange = viewModel::setTargetDomainName,
+                    onClickAddInitialWildcard = { viewModel.setInitialDomainName(formUiState.initialDomainName + "*.") },
+                    onClickAddTargetWildcard = { viewModel.setTargetDomainName(formUiState.targetDomainName + "*.") }
                 )
             }
 
@@ -127,6 +129,7 @@ fun AddRuleScreen(
                     showHints = uiState.showFormFieldHints,
                     onRuleNameChange = viewModel::setRuleName,
                     onDomainNameChange = viewModel::setDomainName,
+                    onClickAddWildcard = { viewModel.setDomainName(formUiState.domainName + "*.") }
                 )
             }
 
@@ -141,6 +144,7 @@ fun AddRuleScreen(
                     onDomainNameChange = viewModel::setDomainName,
                     onClickAddParam = { openParamNameDialog = true },
                     onClickDismissParam = viewModel::removeParam,
+                    onClickAddWildcard = { viewModel.setDomainName(formUiState.domainName + "*.") }
                 )
 
                 if (openParamNameDialog) {
@@ -326,6 +330,7 @@ fun AddRuleScreenPreview() {
                 onDomainNameChange = {},
                 onClickAddParam = {},
                 onClickDismissParam = {},
+                onClickAddWildcard = {},
             )
         }
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/DomainNameValidator.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/DomainNameValidator.kt
@@ -6,6 +6,10 @@ import javax.inject.Inject
 
 class DomainNameValidator @Inject constructor() : Validator {
     override fun isValid(domainName: String): Boolean {
+        if (domainName.startsWith("*.")) {
+            return Patterns.DOMAIN_NAME.matcher(domainName.removePrefix("*.")).matches()
+        }
+
         return Patterns.DOMAIN_NAME.matcher(domainName).matches()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="content_description_more_options">More options</string>
     <string name="show_hints">Show hints</string>
     <string name="domain_name">Domain name</string>
-    <string name="domain_name_supporting_text">The domain name that links of should be affected by this rule.</string>
+    <string name="domain_name_supporting_text">The domain name that this rule applies to.</string>
     <string name="delete">Delete</string>
     <string name="url_parameter_name">URL parameter name</string>
     <string name="domain_name_blank_error">Domain name can\'t be blank</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,6 @@
 
     <!-- format: "{rule type} on {trigger domain}. {present simple tense rule desc}." -->
     <string name="cd_rules_list_item">%1$s on %2$s. %3$s.</string>
+
+    <string name="cd_add_wildcard_operator">Add wildcard operator</string>
 </resources>

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
@@ -58,13 +58,14 @@ class MutateUriUseCaseTest {
             )
         ),
         DomainNameAndSpecificUrlParamsMutationModel(
-            name = "YouTube mobile remove 'list' param",
-            triggerDomain = "m.youtube.com",
+            name = "Wikipedia convert mobile link to desktop and remove 's' parameter (attached " +
+                    "by Twitter to outbound links)",
+            triggerDomain = "en.m.wikipedia.org",
             isLocalOnly = true,
             mutationInfo = DomainNameAndSpecificUrlParamsMutationInfo(
-                initialDomainName = "m.youtube.com",
-                targetDomainName = "www.youtube.com",
-                removableParams = listOf("list")
+                initialDomainName = "en.m.wikipedia.org",
+                targetDomainName = "en.wikipedia.org",
+                removableParams = listOf("s")
             )
         )
     )
@@ -128,10 +129,10 @@ class MutateUriUseCaseTest {
     @Test(expected = NotImplementedError::class)
     fun `apply DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC custom rule`() {
         val actual = mutateUriUseCase(
-            URI("https://m.youtube.com/watch?v=B91ztNPq_cs&list=PLWz5rJ2EKKc8L8WlmqPD6zPEyVSKrL5PJ"),
+            URI("https://en.m.wikipedia.org/wiki/Android_(operating_system)?s=09"),
             mockCustomRules
         )
-        val expected = URI("https://www.youtube.com/watch?v=B91ztNPq_cs")
+        val expected = URI("https://en.wikipedia.org/wiki/Android_(operating_system)")
         assertEquals(expected, actual)
     }
 

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
@@ -42,7 +42,7 @@ class MutateUriUseCaseTest {
         ),
         SpecificUrlParamsMutationModel(
             name = "YouTube remove 'list' param",
-            triggerDomain = "youtube.com",
+            triggerDomain = "*.youtube.com",
             isLocalOnly = true,
             mutationInfo = SpecificUrlParamsMutationInfo(
                 removableParams = listOf("list")
@@ -114,6 +114,23 @@ class MutateUriUseCaseTest {
         )
         val expected = URI("https://www.youtube.com/watch?v=B91ztNPq_cs")
         assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `apply URL_PARAMS_SPECIFIC custom rule, test wildcard functionality`() {
+        val actual1 = mutateUriUseCase(
+            URI("https://m.youtube.com/watch?v=B91ztNPq_cs&list=PLWz5rJ2EKKc8L8WlmqPD6zPEyVSKrL5PJ"),
+            mockCustomRules
+        )
+        val expected1 = URI("https://m.youtube.com/watch?v=B91ztNPq_cs")
+        assertEquals(expected1, actual1)
+
+        val actual2 = mutateUriUseCase(
+            URI("https://not-a-real-subdomain.youtube.com/watch?v=B91ztNPq_cs&list=PLWz5rJ2EKKc8L8WlmqPD6zPEyVSKrL5PJ"),
+            mockCustomRules
+        )
+        val expected2 = URI("https://not-a-real-subdomain.youtube.com/watch?v=B91ztNPq_cs")
+        assertEquals(expected2, actual2)
     }
 
     @Test

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/validation/ValidateDomainNameUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/validation/ValidateDomainNameUseCaseTest.kt
@@ -1,7 +1,5 @@
-package com.suvanl.fixmylinks.validation
+package com.suvanl.fixmylinks.domain.validation
 
-import com.suvanl.fixmylinks.domain.validation.ValidateDomainNameUseCase
-import com.suvanl.fixmylinks.domain.validation.Validator
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/validation/ValidateRemovableParamsListUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/validation/ValidateRemovableParamsListUseCaseTest.kt
@@ -1,6 +1,5 @@
-package com.suvanl.fixmylinks.validation
+package com.suvanl.fixmylinks.domain.validation
 
-import com.suvanl.fixmylinks.domain.validation.ValidateRemovableParamsListUseCase
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/validation/ValidateUrlParamKeyUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/validation/ValidateUrlParamKeyUseCaseTest.kt
@@ -1,6 +1,5 @@
-package com.suvanl.fixmylinks.validation
+package com.suvanl.fixmylinks.domain.validation
 
-import com.suvanl.fixmylinks.domain.validation.ValidateUrlParamKeyUseCase
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

- Eliminates the need to create multiple rules to match multiple subdomains of a domain. This can be extremely tedious if you want to match every possible subdomain of a domain, such as if you want to convert `<any subdomain>.google.com` to `<any subdomain>.google.fr`, or if you want to remove a specific parameter from `<any subdomain>`.youtube.com, including the apex domain (`youtube.com`).
- Consequently closes #34
  - An implemented behaviour that isn't mentioned in the linked issue is that a wildcard subdomain is allowed in the targetDomain of a DOMAIN_NAME rule; using it ensures that any subdomain in the link extracted from the shared content will be retained.


## 🧑‍💻 Implementation/changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
### Business logic
- ✨ (MutateUriUseCase): Support wildcard operator when finding rule (in `findRule()`) (916c3d83f255805b91431ca489e81591f5f8a3d1)
  - If the rule being iterated over has a triggerDomain starting with "*.", the wildcard subdomain is removed from triggerDomain when comparing it to the `URI.host`, which also has its subdomain (whatever it may be) removed during the comparison, thus achieving wildcard behaviour since any subdomain (and the apex domain) will therefore be matched, as per the specification in the linked issue.
- 🦺 (DomainNameValidator): Allow wildcard character ("*") in subdomain (238306dd6561dfe412fe5b5f55a42911ac3be623)
  - If the domain has multiple subdomains (such as "auth.prod.example.com"), the wildcard character will only apply to the first one
- ✨ (ReplaceDomainNameUseCase): Support subdomain wildcard operator in initialDomain and targetDomain (f51a190c7787cba88017ef9ac3deddc02ae70402)
  - If the target domain starts with a wildcard subdomain, retain the subdomain that was present in the given `java.net.URI` instance's `host` property


### UI
- ✨ Display an "add wildcard operator" button in domain name fields (in the `OutlinedTextField`'s `trailingIcon` argument) (34497a1)
  - When clicked, adds "*." to the field (if it is blank) by modifying the field's state in the ViewModel
- 🚸 (domain name fields): Request focus when AddWildcardButton is clicked (6745a76)


## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
### Instrumentation
- ✅ (MutateUriUseCaseTest): Add test for wildcard operator functionality (4607f4a65dabba177076d1e34c3a71bc752fd7d4)
- ✅ Add tests to verify that AddWildcardButton is displayed in domain name fields under expected conditions (89436b72a16a223bd8d95948eb734ac7b665ea04)
  - The conditions are as follows:
    - if field value is empty: ✔️ show button
    - if field value is blank: ✔️ show button
    - if field value is not blank (and thus not empty): ❌ hide button

## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A