### PR TITLE
🐛 (AddRuleScreen): Fix bug where "Enabled" option switch does nothing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        api-level: [29, 34]
+        api-level: [33, 34]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/data/local/db/RuleDatabaseTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/data/local/db/RuleDatabaseTest.kt
@@ -415,7 +415,8 @@ class RuleDatabaseTest {
                 authorId = DEFAULT_AUTHOR_ID,
                 mutationType = MutationType.URL_PARAMS_ALL,
                 triggerDomain = "instagram.com",
-                isLocalOnly = true
+                isLocalOnly = true,
+                isEnabled = true,
             ),
             AllUrlParamsRule(id = 1, baseRuleId = 1)
         )
@@ -427,7 +428,8 @@ class RuleDatabaseTest {
                 authorId = DEFAULT_AUTHOR_ID,
                 mutationType = MutationType.URL_PARAMS_ALL,
                 triggerDomain = "spotify.com",
-                isLocalOnly = true
+                isLocalOnly = true,
+                isEnabled = true,
             ),
             AllUrlParamsRule(id = 2, baseRuleId = 2)
         )
@@ -439,6 +441,7 @@ class RuleDatabaseTest {
                 authorId = DEFAULT_AUTHOR_ID,
                 mutationType = MutationType.DOMAIN_NAME,
                 triggerDomain = "twitter.com",
+                isEnabled = true,
                 isLocalOnly = true
             ),
             DomainNameRule(
@@ -456,6 +459,7 @@ class RuleDatabaseTest {
                 authorId = DEFAULT_AUTHOR_ID,
                 mutationType = MutationType.URL_PARAMS_ALL,
                 triggerDomain = "medium.com",
+                isEnabled = true,
                 isLocalOnly = true
             ),
             AllUrlParamsRule(id = 3, baseRuleId = 4)
@@ -468,6 +472,7 @@ class RuleDatabaseTest {
                 authorId = DEFAULT_AUTHOR_ID,
                 mutationType = MutationType.DOMAIN_NAME_AND_URL_PARAMS_ALL,
                 triggerDomain = "d.android.com",
+                isEnabled = true,
                 isLocalOnly = true
             ),
             DomainNameAndAllUrlParamsRule(
@@ -485,6 +490,7 @@ class RuleDatabaseTest {
                 authorId = DEFAULT_AUTHOR_ID,
                 mutationType = MutationType.DOMAIN_NAME_AND_URL_PARAMS_SPECIFIC,
                 triggerDomain = "google.com",
+                isEnabled = true,
                 isLocalOnly = true
             ),
             DomainNameAndSpecificUrlParamsRule(
@@ -503,6 +509,7 @@ class RuleDatabaseTest {
                 authorId = DEFAULT_AUTHOR_ID,
                 mutationType = MutationType.URL_PARAMS_SPECIFIC,
                 triggerDomain = "youtube.com",
+                isEnabled = true,
                 isLocalOnly = true
             ),
             SpecificUrlParamsRule(

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -194,6 +194,7 @@ class RulesScreenTest {
                 name = "Google rule",
                 triggerDomain = "google.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 dateModifiedTimestamp = 1700174822,
                 mutationInfo = DomainNameMutationInfo(
                     initialDomain = "google.com",
@@ -205,6 +206,7 @@ class RulesScreenTest {
                 name = "YouTube - remove playlist association and timestamp, but nothing else",
                 triggerDomain = "youtube.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 dateModifiedTimestamp = 1701970463,
                 mutationInfo = SpecificUrlParamsMutationInfo(
                     removableParams = listOf("list", "t")
@@ -215,6 +217,7 @@ class RulesScreenTest {
                 name = "Google rule 2",
                 triggerDomain = "google.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 dateModifiedTimestamp = 1700174823,
                 mutationInfo = DomainNameMutationInfo(
                     initialDomain = "google.fr",
@@ -226,6 +229,7 @@ class RulesScreenTest {
                 name = "remove all params from reddit links",
                 triggerDomain = "reddit.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 dateModifiedTimestamp = 1702899122,
                 baseRuleId = 4,
             ),

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
@@ -62,6 +62,7 @@ class RuleDetailsScreenTest {
                     triggerDomain = "github.com",
                     dateModifiedTimestamp = 0,
                     isLocalOnly = true,
+                    isEnabled = true,
                     baseRuleId = 1
                 ),
                 showDeleteConfirmation = false,
@@ -84,6 +85,7 @@ class RuleDetailsScreenTest {
                     triggerDomain = "github.com",
                     dateModifiedTimestamp = 0,
                     isLocalOnly = true,
+                    isEnabled = true,
                     baseRuleId = 1
                 ),
                 showDeleteConfirmation = false,
@@ -112,6 +114,7 @@ class RuleDetailsScreenTest {
                     triggerDomain = "google.com",
                     dateModifiedTimestamp = 0,
                     isLocalOnly = true,
+                    isEnabled = true,
                     baseRuleId = 1,
                     mutationInfo = DomainNameMutationInfo(
                         initialDomain = "google.com",
@@ -144,6 +147,7 @@ class RuleDetailsScreenTest {
                     triggerDomain = "google.com",
                     dateModifiedTimestamp = 0,
                     isLocalOnly = true,
+                    isEnabled = true,
                     baseRuleId = 1,
                     mutationInfo = DomainNameMutationInfo(
                         initialDomain = "google.com",
@@ -176,6 +180,7 @@ class RuleDetailsScreenTest {
                     triggerDomain = "youtube.com",
                     dateModifiedTimestamp = 0,
                     isLocalOnly = true,
+                    isEnabled = true,
                     baseRuleId = 1,
                     mutationInfo = SpecificUrlParamsMutationInfo(
                         removableParams = listOf("list", "t")
@@ -207,6 +212,7 @@ class RuleDetailsScreenTest {
                     triggerDomain = "youtube.com",
                     dateModifiedTimestamp = 0,
                     isLocalOnly = true,
+                    isEnabled = true,
                     baseRuleId = 1,
                     mutationInfo = SpecificUrlParamsMutationInfo(
                         removableParams = listOf("list", "t")

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreenTest.kt
@@ -32,7 +32,9 @@ class AddRuleScreenTest {
         AddRuleScreenBody(
             mutationType = mutationType,
             showSaveButton = layoutClass.lowercase() == "compact",
-            onSaveClick = {}
+            onSaveClick = {},
+            ruleOptions = RuleOptionsState(),
+            onOptionsChanged = {},
         ) {
             when (mutationType) {
                 MutationType.URL_PARAMS_SPECIFIC -> {

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/RuleDatabase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/RuleDatabase.kt
@@ -27,7 +27,7 @@ import com.suvanl.fixmylinks.data.local.db.entity.SpecificUrlParamsRule
         DomainNameRule::class,
         SpecificUrlParamsRule::class,
     ],
-    version = 1,
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/suvanl/fixmylinks/data/local/db/entity/BaseRule.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/local/db/entity/BaseRule.kt
@@ -26,4 +26,7 @@ data class BaseRule(
 
     @ColumnInfo(name = "local_only")
     val isLocalOnly: Boolean,
+
+    @ColumnInfo(name = "is_enabled")
+    val isEnabled: Boolean,
 )

--- a/app/src/main/java/com/suvanl/fixmylinks/data/repository/CustomRulesRepository.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/data/repository/CustomRulesRepository.kt
@@ -308,6 +308,7 @@ class CustomRulesRepository @Inject constructor(
                     triggerDomain = baseRule.triggerDomain,
                     dateModifiedTimestamp = baseRule.dateModified,
                     isLocalOnly = baseRule.isLocalOnly,
+                    isEnabled = baseRule.isEnabled,
                 )
             }
 
@@ -318,6 +319,7 @@ class CustomRulesRepository @Inject constructor(
                     triggerDomain = baseRule.triggerDomain,
                     dateModifiedTimestamp = baseRule.dateModified,
                     isLocalOnly = baseRule.isLocalOnly,
+                    isEnabled = baseRule.isEnabled,
                     mutationInfo = DomainNameMutationInfo(
                         initialDomain = genericRule.initialDomainName,
                         targetDomain = genericRule.targetDomainName
@@ -332,6 +334,7 @@ class CustomRulesRepository @Inject constructor(
                     triggerDomain = baseRule.triggerDomain,
                     dateModifiedTimestamp = baseRule.dateModified,
                     isLocalOnly = baseRule.isLocalOnly,
+                    isEnabled = baseRule.isEnabled,
                     mutationInfo = DomainNameAndSpecificUrlParamsMutationInfo(
                         initialDomainName = genericRule.initialDomainName,
                         targetDomainName = genericRule.targetDomainName,
@@ -347,6 +350,7 @@ class CustomRulesRepository @Inject constructor(
                     triggerDomain = baseRule.triggerDomain,
                     dateModifiedTimestamp = baseRule.dateModified,
                     isLocalOnly = baseRule.isLocalOnly,
+                    isEnabled = baseRule.isEnabled,
                     mutationInfo = DomainNameMutationInfo(
                         initialDomain = genericRule.initialDomainName,
                         targetDomain = genericRule.targetDomainName
@@ -361,6 +365,7 @@ class CustomRulesRepository @Inject constructor(
                     triggerDomain = baseRule.triggerDomain,
                     dateModifiedTimestamp = baseRule.dateModified,
                     isLocalOnly = baseRule.isLocalOnly,
+                    isEnabled = baseRule.isEnabled,
                     mutationInfo = SpecificUrlParamsMutationInfo(
                         removableParams = genericRule.removableParams
                     )

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCase.kt
@@ -78,9 +78,9 @@ class MutateUriUseCase @Inject constructor() {
                 // Wildcard operator functionality: compare triggerDomain and URI.host without
                 // subdomain on both sides of the equality check.
                 // Note that URI.removeSubdomain("*") removes any subdomain that the URI.host may contain.
-                rule.triggerDomain.removePrefix("*.") == uri.removeSubdomain("*").host
+                rule.isEnabled && rule.triggerDomain.removePrefix("*.") == uri.removeSubdomain("*").host
             } else {
-                rule.triggerDomain == uri.host
+                rule.isEnabled && rule.triggerDomain == uri.host
             }
         }
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/AllUrlParamsMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/AllUrlParamsMutationModel.kt
@@ -9,6 +9,7 @@ data class AllUrlParamsMutationModel(
     override val triggerDomain: String,
     override val dateModifiedTimestamp: Long? = null,
     override val isLocalOnly: Boolean,
+    override val isEnabled: Boolean,
     override val baseRuleId: Long = 0,
 ) : BaseMutationModel
 

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/BaseMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/BaseMutationModel.kt
@@ -36,6 +36,11 @@ interface BaseMutationModel {
     val isLocalOnly: Boolean
 
     /**
+     * Whether the rule should be applied when a link containing the rule's triggerDomain is shared
+     */
+    val isEnabled: Boolean
+
+    /**
      * The ID of the base rule related to this rule in the local database.
      */
     val baseRuleId: Long
@@ -48,5 +53,6 @@ fun BaseMutationModel.toDatabaseEntity() = BaseRule(
     triggerDomain = triggerDomain,
     dateModified = dateModifiedTimestamp ?: (System.currentTimeMillis() / 1000),
     isLocalOnly = isLocalOnly,
+    isEnabled = isEnabled,
     authorId = "local_user"
 )

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameAndAllUrlParamsMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameAndAllUrlParamsMutationModel.kt
@@ -9,6 +9,7 @@ data class DomainNameAndAllUrlParamsMutationModel(
     override val triggerDomain: String,
     override val dateModifiedTimestamp: Long? = null,
     override val isLocalOnly: Boolean,
+    override val isEnabled: Boolean,
     override val baseRuleId: Long = 0,
     val mutationInfo: DomainNameMutationInfo
 ) : BaseMutationModel

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameAndSpecificUrlParamsMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameAndSpecificUrlParamsMutationModel.kt
@@ -15,6 +15,7 @@ data class DomainNameAndSpecificUrlParamsMutationModel(
     override val triggerDomain: String,
     override val dateModifiedTimestamp: Long? = null,
     override val isLocalOnly: Boolean,
+    override val isEnabled: Boolean,
     override val baseRuleId: Long = 0,
     val mutationInfo: DomainNameAndSpecificUrlParamsMutationInfo,
 ) : BaseMutationModel

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/DomainNameMutationModel.kt
@@ -14,6 +14,7 @@ data class DomainNameMutationModel(
     override val triggerDomain: String,
     override val dateModifiedTimestamp: Long? = null,
     override val isLocalOnly: Boolean,
+    override val isEnabled: Boolean,
     override val baseRuleId: Long = 0,
     val mutationInfo: DomainNameMutationInfo,
 ) : BaseMutationModel

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/SpecificUrlParamsMutationModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/model/SpecificUrlParamsMutationModel.kt
@@ -13,6 +13,7 @@ data class SpecificUrlParamsMutationModel(
     override val triggerDomain: String,
     override val dateModifiedTimestamp: Long? = null,
     override val isLocalOnly: Boolean,
+    override val isEnabled: Boolean,
     override val baseRuleId: Long = 0,
     val mutationInfo: SpecificUrlParamsMutationInfo,
 ) : BaseMutationModel

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/rule/BuiltInRules.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/rule/BuiltInRules.kt
@@ -10,6 +10,7 @@ object BuiltInRules {
         name = "Spotify - tracking parameters",
         triggerDomain = "spotify.com",
         isLocalOnly = true,
+        isEnabled = true,
         mutationInfo = SpecificUrlParamsMutationInfo(
             removableParams = listOf(
                 "si",
@@ -24,6 +25,7 @@ object BuiltInRules {
         name = "Instagram - tracking parameters",
         triggerDomain = "instagram.com",
         isLocalOnly = true,
+        isEnabled = true,
         mutationInfo = SpecificUrlParamsMutationInfo(removableParams = listOf("igshid"))
     )
 
@@ -31,6 +33,7 @@ object BuiltInRules {
         name = "X.com to Twitter.com",
         triggerDomain = "x.com",
         isLocalOnly = true,
+        isEnabled = true,
         mutationInfo = DomainNameMutationInfo(initialDomain = "x.com", targetDomain = "twitter.com")
     )
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
@@ -180,6 +180,7 @@ private fun ItemSelectedPreview() {
                 mutationType = MutationType.FALLBACK,
                 triggerDomain = "youtube.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 dateModifiedTimestamp = 1701970463,
                 mutationInfo = SpecificUrlParamsMutationInfo(
                     removableParams = listOf("list", "t")

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -48,7 +48,6 @@ import com.suvanl.fixmylinks.ui.screens.SavedScreen
 import com.suvanl.fixmylinks.ui.screens.details.RuleDetailsScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreen
 import com.suvanl.fixmylinks.ui.screens.newruleflow.AddRuleScreenUiState
-import com.suvanl.fixmylinks.ui.screens.newruleflow.RuleOptionsState
 import com.suvanl.fixmylinks.ui.screens.newruleflow.SelectRuleTypeScreen
 import com.suvanl.fixmylinks.ui.theme.TextStyleDefaults
 import com.suvanl.fixmylinks.ui.util.getNewRuleFlowViewModel
@@ -302,6 +301,7 @@ fun FmlNavHost(
 
                 val viewModel: AddRuleViewModel = getNewRuleFlowViewModel(mutationType)
                 val userPreferences by viewModel.userPreferences.collectAsStateWithLifecycle()
+                val ruleOptions by viewModel.ruleOptions.collectAsStateWithLifecycle()
 
                 val isCompactLayout = windowWidthSize == WindowWidthSizeClass.Compact
                 var hintsOptionCheckedState by remember { mutableStateOf(true) }
@@ -352,10 +352,11 @@ fun FmlNavHost(
                         mutationType = mutationType,
                         showFormFieldHints = userPreferences.showFormFieldHints,
                         showSaveButton = isCompactLayout,
-                        ruleOptions = RuleOptionsState(),
+                        ruleOptions = ruleOptions,
                     ),
                     viewModel = viewModel,
                     onSaveClick = { handleSaveRuleClick() },
+                    onOptionsChanged = viewModel::updateRuleOptionsState,
                     action = action,
                     baseRuleId = baseRuleId,
                 )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/Scale.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/transition/Scale.kt
@@ -2,8 +2,7 @@ package com.suvanl.fixmylinks.ui.navigation.transition
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
-import androidx.compose.animation.core.EaseOut
-import androidx.compose.animation.core.EaseOutExpo
+import androidx.compose.animation.core.EaseOutQuint
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -18,16 +17,16 @@ fun scaleIntoContainer(
 ): EnterTransition {
     return scaleIn(
         animationSpec = tween(
-            durationMillis = 120,
+            durationMillis = 400,
             delayMillis = 90,
-            easing = EaseOut
+            easing = EaseOutQuint
         ),
         initialScale = initialScale,
     ) + fadeIn(
         animationSpec = tween(
-            durationMillis = 250,
+            durationMillis = 500,
             delayMillis = 90,
-            easing = EaseOut
+            easing = EaseOutQuint
         )
     )
 }
@@ -38,15 +37,15 @@ fun scaleOutOfContainer(
 ): ExitTransition {
     return scaleOut(
         animationSpec = tween(
-            durationMillis = 120,
-            delayMillis = 90
+            durationMillis = 400,
+            delayMillis = 0
         ),
         targetScale = targetScale
     ) + fadeOut(
         animationSpec = tween(
             durationMillis = 220,
             delayMillis = 0,
-            easing = EaseOutExpo
+            easing = EaseOutQuint
         )
     )
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/newruleflow/AddRuleScreen.kt
@@ -27,9 +27,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.Saver
-import androidx.compose.runtime.saveable.listSaver
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -67,26 +64,14 @@ data class RuleOptionsState(
     val ruleEnabled: Boolean = true,
     val keepContent: Boolean = false,
     val backupEnabled: Boolean = false,
-) {
-    companion object {
-        val saver: Saver<RuleOptionsState, *> = listSaver(
-            save = { listOf(it.ruleEnabled, it.keepContent, it.backupEnabled) },
-            restore = {
-                RuleOptionsState(
-                    ruleEnabled = it[0],
-                    keepContent = it[1],
-                    backupEnabled = it[2],
-                )
-            }
-        )
-    }
-}
+)
 
 @Composable
 fun AddRuleScreen(
     uiState: AddRuleScreenUiState,
     viewModel: AddRuleViewModel,
     onSaveClick: () -> Unit,
+    onOptionsChanged: (options: RuleOptionsState) -> Unit,
     modifier: Modifier = Modifier,
     action: FmlScreen.AddRule.Action = FmlScreen.AddRule.Action.ADD,
     baseRuleId: Long = 0,
@@ -95,6 +80,8 @@ fun AddRuleScreen(
         mutationType = uiState.mutationType,
         showSaveButton = uiState.showSaveButton,
         onSaveClick = onSaveClick,
+        ruleOptions = uiState.ruleOptions,
+        onOptionsChanged = onOptionsChanged,
         modifier = modifier
     ) {
         LaunchedEffect(action, baseRuleId) {
@@ -178,27 +165,25 @@ fun AddRuleScreenBody(
     mutationType: MutationType,
     showSaveButton: Boolean,
     onSaveClick: () -> Unit,
+    ruleOptions: RuleOptionsState,
+    onOptionsChanged: (options: RuleOptionsState) -> Unit,
     modifier: Modifier = Modifier,
     form: @Composable () -> Unit,
 ) {
-    var ruleOptions by rememberSaveable(stateSaver = RuleOptionsState.saver) {
-        mutableStateOf(RuleOptionsState())
-    }
-
     val switchListItems = listOf(
         SwitchListItemState(
             headlineText = stringResource(id = R.string.enable),
             supportingText = stringResource(R.string.enable_rule_supporting_text),
             leadingIcon = Icons.Outlined.CheckCircle,
             isSwitchChecked = ruleOptions.ruleEnabled,
-            onSwitchCheckedChange = { ruleOptions = ruleOptions.copy(ruleEnabled = it) },
+            onSwitchCheckedChange = { onOptionsChanged(ruleOptions.copy(ruleEnabled = it)) },
         ),
         SwitchListItemState(
             headlineText = stringResource(R.string.keep_content),
             supportingText = stringResource(R.string.keep_content_supporting_text),
             leadingIcon = Icons.Outlined.Segment,
             isSwitchChecked = ruleOptions.keepContent,
-            onSwitchCheckedChange = { ruleOptions = ruleOptions.copy(keepContent = it) },
+            onSwitchCheckedChange = { onOptionsChanged(ruleOptions.copy(keepContent = it)) },
             comingSoon = true,
         ),
         SwitchListItemState(
@@ -206,7 +191,7 @@ fun AddRuleScreenBody(
             supportingText = stringResource(R.string.backup_to_cloud_supporting_text),
             leadingIcon = Icons.Outlined.Backup,
             isSwitchChecked = ruleOptions.backupEnabled,
-            onSwitchCheckedChange = { ruleOptions = ruleOptions.copy(backupEnabled = it) },
+            onSwitchCheckedChange = { onOptionsChanged(ruleOptions.copy(backupEnabled = it)) },
             comingSoon = true,
         ),
     )
@@ -321,7 +306,9 @@ fun AddRuleScreenPreview() {
         AddRuleScreenBody(
             mutationType = MutationType.URL_PARAMS_SPECIFIC,
             showSaveButton = true,
-            onSaveClick = {}
+            onSaveClick = {},
+            ruleOptions = RuleOptionsState(),
+            onOptionsChanged = {},
         ) {
             SpecificUrlParamsRuleForm(
                 showHints = true,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/PreviewData.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/PreviewData.kt
@@ -14,6 +14,7 @@ object PreviewData {
             name = "Google rule",
             triggerDomain = "google.com",
             isLocalOnly = true,
+            isEnabled = true,
             dateModifiedTimestamp = 1700174822,
             mutationInfo = DomainNameMutationInfo(
                 initialDomain = "google.com",
@@ -24,6 +25,7 @@ object PreviewData {
             name = "YouTube - remove playlist association and timestamp, but nothing else",
             triggerDomain = "youtube.com",
             isLocalOnly = true,
+            isEnabled = true,
             dateModifiedTimestamp = 1701970463,
             mutationInfo = SpecificUrlParamsMutationInfo(
                 removableParams = listOf("list", "t")

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModel.kt
@@ -39,6 +39,7 @@ class AddAllUrlParamsRuleViewModel @Inject constructor(
                 ruleName = rule.name,
                 domainName = rule.triggerDomain,
             )
+            updateRuleOptionsState(ruleOptions.value.copy(ruleEnabled = rule.isEnabled))
         }
     }
 
@@ -51,6 +52,7 @@ class AddAllUrlParamsRuleViewModel @Inject constructor(
                 mutationType = MutationType.URL_PARAMS_ALL,
                 triggerDomain = _formUiState.value.domainName,
                 isLocalOnly = true,
+                isEnabled = ruleOptions.value.ruleEnabled,
             )
         )
     }
@@ -62,6 +64,7 @@ class AddAllUrlParamsRuleViewModel @Inject constructor(
             name = _formUiState.value.ruleName,
             triggerDomain = _formUiState.value.domainName,
             isLocalOnly = true,
+            isEnabled = ruleOptions.value.ruleEnabled,
             baseRuleId = baseRuleId
         )
         rulesRepository.get().updateRule(baseRuleId, newData)

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModel.kt
@@ -54,12 +54,14 @@ class AddDomainNameRuleViewModel @Inject constructor(
                     initialDomainName = rule.mutationInfo.initialDomain,
                     targetDomainName = rule.mutationInfo.targetDomain,
                 )
+                updateRuleOptionsState(ruleOptions.value.copy(ruleEnabled = rule.isEnabled))
             } else if (rule is DomainNameAndAllUrlParamsMutationModel) {
                 _formUiState.value = DomainNameRuleFormState(
                     ruleName = rule.name,
                     initialDomainName = rule.mutationInfo.initialDomain,
                     targetDomainName = rule.mutationInfo.targetDomain,
                 )
+                updateRuleOptionsState(ruleOptions.value.copy(ruleEnabled = rule.isEnabled))
             }
         }
     }
@@ -75,6 +77,7 @@ class AddDomainNameRuleViewModel @Inject constructor(
                     name = _formUiState.value.ruleName,
                     triggerDomain = _formUiState.value.initialDomainName,
                     isLocalOnly = true,
+                    isEnabled = ruleOptions.value.ruleEnabled,
                     mutationInfo = DomainNameMutationInfo(
                         initialDomain = _formUiState.value.initialDomainName,
                         targetDomain = _formUiState.value.targetDomainName,
@@ -90,6 +93,7 @@ class AddDomainNameRuleViewModel @Inject constructor(
                 name = _formUiState.value.ruleName,
                 triggerDomain = _formUiState.value.initialDomainName,
                 isLocalOnly = true,
+                isEnabled = ruleOptions.value.ruleEnabled,
                 mutationInfo = DomainNameMutationInfo(
                     initialDomain = _formUiState.value.initialDomainName,
                     targetDomain = _formUiState.value.targetDomainName,
@@ -109,6 +113,7 @@ class AddDomainNameRuleViewModel @Inject constructor(
                 name = _formUiState.value.ruleName,
                 triggerDomain = _formUiState.value.initialDomainName,
                 isLocalOnly = true,
+                isEnabled = ruleOptions.value.ruleEnabled,
                 mutationInfo = DomainNameMutationInfo(
                     initialDomain = _formUiState.value.initialDomainName,
                     targetDomain = _formUiState.value.targetDomainName,
@@ -124,6 +129,7 @@ class AddDomainNameRuleViewModel @Inject constructor(
             name = _formUiState.value.ruleName,
             triggerDomain = _formUiState.value.initialDomainName,
             isLocalOnly = true,
+            isEnabled = ruleOptions.value.ruleEnabled,
             mutationInfo = DomainNameMutationInfo(
                 initialDomain = _formUiState.value.initialDomainName,
                 targetDomain = _formUiState.value.targetDomainName,

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddRuleViewModel.kt
@@ -6,8 +6,11 @@ import com.suvanl.fixmylinks.data.repository.PreferencesRepository
 import com.suvanl.fixmylinks.data.repository.UserPreferences
 import com.suvanl.fixmylinks.data.repository.UserPreferencesRepository
 import com.suvanl.fixmylinks.domain.mutation.MutationType
+import com.suvanl.fixmylinks.ui.screens.newruleflow.RuleOptionsState
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 
 abstract class AddRuleViewModel(
@@ -22,6 +25,13 @@ abstract class AddRuleViewModel(
             started = SharingStarted.WhileSubscribed(stopTimeoutMillis = TIMEOUT_MILLIS),
             initialValue = UserPreferences()
         )
+
+    private val _ruleOptions = MutableStateFlow(RuleOptionsState())
+    val ruleOptions = _ruleOptions.asStateFlow()
+
+    fun updateRuleOptionsState(updatedState: RuleOptionsState) {
+        _ruleOptions.value = updatedState
+    }
 
     /**
      * Sets the initial form UI state with non-default values.

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModel.kt
@@ -61,6 +61,7 @@ class AddSpecificUrlParamsRuleViewModel @Inject constructor(
                 domainName = rule.triggerDomain,
                 addedParamNames = rule.mutationInfo.removableParams,
             )
+            updateRuleOptionsState(ruleOptions.value.copy(ruleEnabled = rule.isEnabled))
         }
     }
 
@@ -72,6 +73,7 @@ class AddSpecificUrlParamsRuleViewModel @Inject constructor(
                 name = _formUiState.value.ruleName,
                 triggerDomain = _formUiState.value.domainName,
                 isLocalOnly = true,
+                isEnabled = ruleOptions.value.ruleEnabled,
                 mutationInfo = SpecificUrlParamsMutationInfo(
                     removableParams = _formUiState.value.addedParamNames
                 )
@@ -86,6 +88,7 @@ class AddSpecificUrlParamsRuleViewModel @Inject constructor(
             name = _formUiState.value.ruleName,
             triggerDomain = _formUiState.value.domainName,
             isLocalOnly = true,
+            isEnabled = ruleOptions.value.ruleEnabled,
             baseRuleId = baseRuleId,
             mutationInfo = SpecificUrlParamsMutationInfo(
                 removableParams = _formUiState.value.addedParamNames

--- a/app/src/test/java/com/suvanl/fixmylinks/data/repository/FakeRulesRepository.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/data/repository/FakeRulesRepository.kt
@@ -89,18 +89,21 @@ class FakeRulesRepository : RulesRepository {
                 name = "My rule",
                 triggerDomain = "instagram.com",
                 isLocalOnly = true,
+                isEnabled = true,
             ),
             AllUrlParamsMutationModel(
                 baseRuleId = 2,
                 name = "My second rule",
                 triggerDomain = "spotify.com",
                 isLocalOnly = true,
+                isEnabled = true,
             ),
             DomainNameMutationModel(
                 baseRuleId = 3,
                 name = "twitter to x",
                 triggerDomain = "x.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 mutationInfo = DomainNameMutationInfo(
                     initialDomain = "twitter.com",
                     targetDomain = "x.com",
@@ -111,12 +114,14 @@ class FakeRulesRepository : RulesRepository {
                 name = "My second rule",
                 triggerDomain = "spotify.com",
                 isLocalOnly = true,
+                isEnabled = true,
             ),
             DomainNameAndAllUrlParamsMutationModel(
                 baseRuleId = 5,
                 name = "Android Dev",
                 triggerDomain = "developer.android.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 mutationInfo = DomainNameMutationInfo(
                     initialDomain = "developer.android.com",
                     targetDomain = "d.android.com",
@@ -127,6 +132,7 @@ class FakeRulesRepository : RulesRepository {
                 name = "YouTube - remove playlist association",
                 triggerDomain = "youtube.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 mutationInfo = SpecificUrlParamsMutationInfo(
                     removableParams = listOf("list"),
                 ),

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
@@ -24,17 +24,20 @@ class MutateUriUseCaseTest {
         AllUrlParamsMutationModel(
             name = "Reddit remove all params",
             triggerDomain = "reddit.com",
-            isLocalOnly = true
+            isLocalOnly = true,
+            isEnabled = true,
         ),
         AllUrlParamsMutationModel(
             name = "Google Blog",
             triggerDomain = "blog.google",
-            isLocalOnly = true
+            isLocalOnly = true,
+            isEnabled = true,
         ),
         DomainNameAndAllUrlParamsMutationModel(
             name = "Android Developers URL shortener and parameter remover",
             triggerDomain = "developer.android.com",
             isLocalOnly = true,
+            isEnabled = true,
             mutationInfo = DomainNameMutationInfo(
                 initialDomain = "developer.android.com",
                 targetDomain = "d.android.com"
@@ -44,6 +47,7 @@ class MutateUriUseCaseTest {
             name = "YouTube remove 'list' param",
             triggerDomain = "*.youtube.com",
             isLocalOnly = true,
+            isEnabled = true,
             mutationInfo = SpecificUrlParamsMutationInfo(
                 removableParams = listOf("list")
             )
@@ -52,6 +56,7 @@ class MutateUriUseCaseTest {
             name = "Google.com to Google.co.uk",
             triggerDomain = "google.com",
             isLocalOnly = true,
+            isEnabled = true,
             mutationInfo = DomainNameMutationInfo(
                 initialDomain = "google.com",
                 targetDomain = "google.co.uk"
@@ -62,6 +67,7 @@ class MutateUriUseCaseTest {
                     "by Twitter to outbound links)",
             triggerDomain = "en.m.wikipedia.org",
             isLocalOnly = true,
+            isEnabled = true,
             mutationInfo = DomainNameAndSpecificUrlParamsMutationInfo(
                 initialDomainName = "en.m.wikipedia.org",
                 targetDomainName = "en.wikipedia.org",

--- a/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/domain/mutation/MutateUriUseCaseTest.kt
@@ -73,6 +73,16 @@ class MutateUriUseCaseTest {
                 targetDomainName = "en.wikipedia.org",
                 removableParams = listOf("s")
             )
+        ),
+        DomainNameMutationModel(
+            name = "Amazon US to Amazon UK",
+            triggerDomain = "amazon.com",
+            isLocalOnly = true,
+            isEnabled = false,
+            mutationInfo = DomainNameMutationInfo(
+                initialDomain = "amazon.com",
+                targetDomain = "amazon.co.uk"
+            )
         )
     )
 
@@ -156,6 +166,14 @@ class MutateUriUseCaseTest {
             mockCustomRules
         )
         val expected = URI("https://en.wikipedia.org/wiki/Android_(operating_system)")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `custom rule that is not enabled (isEnabled is false) does not get applied`() {
+        val actual = mutateUriUseCase(URI("https://www.amazon.com"), mockCustomRules)
+        // URL doesn't change
+        val expected = URI("https://www.amazon.com")
         assertEquals(expected, actual)
     }
 

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/RulesViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/RulesViewModelTest.kt
@@ -117,6 +117,7 @@ class RulesViewModelTest {
                 name = "test rule 1",
                 triggerDomain = "google.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 mutationInfo = DomainNameMutationInfo(
                     initialDomain = "google.com",
                     targetDomain = "google.co.uk",
@@ -127,18 +128,21 @@ class RulesViewModelTest {
                 name = "My rule",
                 triggerDomain = "instagram.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 baseRuleId = 2,
             ),
             AllUrlParamsMutationModel(
                 name = "Spotify - remove all URL params",
                 triggerDomain = "spotify.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 baseRuleId = 3,
             ),
             SpecificUrlParamsMutationModel(
                 name = "YouTube - remove playlist association",
                 triggerDomain = "youtube.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 mutationInfo = SpecificUrlParamsMutationInfo(
                     removableParams = listOf("list")
                 ),
@@ -148,6 +152,7 @@ class RulesViewModelTest {
                 name = "x to twitter",
                 triggerDomain = "x.com",
                 isLocalOnly = true,
+                isEnabled = true,
                 mutationInfo = DomainNameAndSpecificUrlParamsMutationInfo(
                     initialDomainName = "x.com",
                     targetDomainName = "twitter.com",

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddAllUrlParamsRuleViewModelTest.kt
@@ -89,6 +89,7 @@ class AddAllUrlParamsRuleViewModelTest {
             name = formUiState.ruleName,
             triggerDomain = formUiState.domainName,
             isLocalOnly = true,
+            isEnabled = true,
         )
 
         runBlocking {
@@ -111,6 +112,7 @@ class AddAllUrlParamsRuleViewModelTest {
             name = formUiState.ruleName,
             triggerDomain = formUiState.domainName,
             isLocalOnly = true,
+            isEnabled = true,
         )
 
         // should throw an IAE if a rule with the given baseRuleId can't be found in the data source

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddDomainNameRuleViewModelTest.kt
@@ -76,6 +76,7 @@ class AddDomainNameRuleViewModelTest {
             name = formUiState.ruleName,
             triggerDomain = formUiState.initialDomainName,
             isLocalOnly = true,
+            isEnabled = true,
             mutationInfo = DomainNameMutationInfo(
                 initialDomain = formUiState.initialDomainName,
                 targetDomain = formUiState.targetDomainName,
@@ -101,6 +102,7 @@ class AddDomainNameRuleViewModelTest {
             name = formUiState.ruleName,
             triggerDomain = formUiState.initialDomainName,
             isLocalOnly = true,
+            isEnabled = true,
             mutationInfo = DomainNameMutationInfo(
                 initialDomain = formUiState.initialDomainName,
                 targetDomain = formUiState.targetDomainName,

--- a/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModelTest.kt
+++ b/app/src/test/java/com/suvanl/fixmylinks/viewmodel/newruleflow/AddSpecificUrlParamsRuleViewModelTest.kt
@@ -188,6 +188,7 @@ class AddSpecificUrlParamsRuleViewModelTest {
             name = formUiState.ruleName,
             triggerDomain = formUiState.domainName,
             isLocalOnly = true,
+            isEnabled = true,
             mutationInfo = SpecificUrlParamsMutationInfo(
                 removableParams = formUiState.addedParamNames
             )
@@ -212,6 +213,7 @@ class AddSpecificUrlParamsRuleViewModelTest {
             name = formUiState.ruleName,
             triggerDomain = formUiState.domainName,
             isLocalOnly = true,
+            isEnabled = true,
             mutationInfo = SpecificUrlParamsMutationInfo(
                 removableParams = formUiState.addedParamNames
             )


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

The "Enabled" option switch on AddRuleScreen currently does nothing, despite the expected behaviour being that it disables the rule if the switch is in the off position.



## 🧑‍💻 Implementation/changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
- Add an `isEnabled` property to the BaseRule database entity (column name is `is_enabled`) and BaseMutationModel domain model (and thus to all child classes).
  - Update the RuleDatabase schema version number as the schema has changed with the addition of the `is_enabled` column in the BaseRule table.
- Use AddRuleViewModel as SSOT for RuleOptionsState in AddRuleScreen.
  - The "Enable" switch on this screen is set with the existing (stored) value when editing an existing rule, rather than the default value from RuleOptionsState.
- Update `findRule()` function in MutateUriUseCase by adding the `rule.isEnabled` condition to the predicate in `allRules.find`.
  - This ensures that a rule where `isEnabled` is false will not be applied, as it simply won't be "found".

## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
- Fix parameters in all unit and instrumentation tests:
  - Add isEnabled param to all DB entity and domain model instantiations
  - Add missing parameters to AddRuleScreenBody relating to the current RuleOptionsState

### Unit testing
- Add test case to MutateUriUseCaseTest to verify that rules where `isEnabled` is false do not get applied.


## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A