### PR TITLE
✨ (ui): Display visual indication of each rule's enabled/disabled status on RulesScreen and RuleDetailsScreen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,27 +104,6 @@ jobs:
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
 
-      - name: AVD cache
-        uses: actions/cache@v3
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: google_apis
-          arch: x86_64
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           arch: x86_64
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
+          disable-animations: true
           script: ./gradlew connectedAndroidTest
 
       - name: Upload instrumentation test summary report

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
@@ -3,7 +3,6 @@ package com.suvanl.fixmylinks.ui.screens.details
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -51,30 +50,6 @@ class RuleDetailsScreenTest {
 
             cancelString = activity.getString(android.R.string.cancel)
         }
-    }
-
-    @Test
-    fun ruleDetailsScreen_isDisplayed() {
-        composeTestRule.setContent {
-            RuleDetailsScreen(
-                rule = AllUrlParamsMutationModel(
-                    name = "My rule",
-                    triggerDomain = "github.com",
-                    dateModifiedTimestamp = 0,
-                    isLocalOnly = true,
-                    isEnabled = true,
-                    baseRuleId = 1
-                ),
-                showDeleteConfirmation = false,
-                onDismissDeleteConfirmation = {},
-                onDelete = {},
-                onEnabledStateChanged = {},
-            )
-        }
-
-        composeTestRule.onNodeWithContentDescription("Rule Details Screen")
-            .assertExists()
-            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
@@ -2,6 +2,11 @@ package com.suvanl.fixmylinks.ui.screens.details
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.hasParent
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -50,6 +55,56 @@ class RuleDetailsScreenTest {
 
             cancelString = activity.getString(android.R.string.cancel)
         }
+    }
+
+    @Test
+    fun ruleDetailsScreen_ruleEnabledSwitch_hasCorrectValue_whenRuleIsEnabled() {
+        composeTestRule.setContent {
+            RuleDetailsScreen(
+                rule = AllUrlParamsMutationModel(
+                    name = "My rule",
+                    triggerDomain = "github.com",
+                    dateModifiedTimestamp = 0,
+                    isLocalOnly = true,
+                    isEnabled = true,
+                    baseRuleId = 1
+                ),
+                showDeleteConfirmation = false,
+                onDismissDeleteConfirmation = {},
+                onDelete = {},
+                onEnabledStateChanged = {},
+            )
+        }
+
+        composeTestRule
+            .onNode(isToggleable() and hasParent(hasTestTag("RuleEnabledSwitch")))
+            .assertExists()
+            .assertIsOn()
+    }
+
+    @Test
+    fun ruleDetailsScreen_ruleEnabledSwitch_hasCorrectValue_whenRuleIsNotEnabled() {
+        composeTestRule.setContent {
+            RuleDetailsScreen(
+                rule = AllUrlParamsMutationModel(
+                    name = "My rule",
+                    triggerDomain = "github.com",
+                    dateModifiedTimestamp = 0,
+                    isLocalOnly = true,
+                    isEnabled = false,
+                    baseRuleId = 1
+                ),
+                showDeleteConfirmation = false,
+                onDismissDeleteConfirmation = {},
+                onDelete = {},
+                onEnabledStateChanged = {},
+            )
+        }
+
+        composeTestRule
+            .onNode(isToggleable() and hasParent(hasTestTag("RuleEnabledSwitch")))
+            .assertExists()
+            .assertIsOff()
     }
 
     @Test

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
@@ -68,6 +68,7 @@ class RuleDetailsScreenTest {
                 showDeleteConfirmation = false,
                 onDismissDeleteConfirmation = {},
                 onDelete = {},
+                onEnabledStateChanged = {},
             )
         }
 
@@ -91,6 +92,7 @@ class RuleDetailsScreenTest {
                 showDeleteConfirmation = false,
                 onDismissDeleteConfirmation = {},
                 onDelete = {},
+                onEnabledStateChanged = {},
             )
         }
 
@@ -124,6 +126,7 @@ class RuleDetailsScreenTest {
                 showDeleteConfirmation = false,
                 onDismissDeleteConfirmation = {},
                 onDelete = {},
+                onEnabledStateChanged = {},
             )
         }
 
@@ -157,6 +160,7 @@ class RuleDetailsScreenTest {
                 showDeleteConfirmation = false,
                 onDismissDeleteConfirmation = {},
                 onDelete = {},
+                onEnabledStateChanged = {},
             )
         }
 
@@ -189,6 +193,7 @@ class RuleDetailsScreenTest {
                 showDeleteConfirmation = false,
                 onDismissDeleteConfirmation = {},
                 onDelete = {},
+                onEnabledStateChanged = {},
             )
         }
 
@@ -221,6 +226,7 @@ class RuleDetailsScreenTest {
                 showDeleteConfirmation = true,
                 onDismissDeleteConfirmation = {},
                 onDelete = {},
+                onEnabledStateChanged = {},
             )
         }
 

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreenTest.kt
@@ -42,16 +42,16 @@ class RuleDetailsScreenTest {
         composeTestRule.apply {
             // Init string resources
             allUrlParamsPstString =
-                activity.getString(R.string.mt_url_params_all_present_simple_tense)
+                activity.getString(R.string.mt_url_params_all_present_simple_tense).replaceFirstChar { it.lowercase() }
 
             domainNameAndAllUrlParamsPstString =
                 activity.getString(R.string.mt_domain_name_and_url_params_all_present_simple_tense)
 
             domainNamePstString =
-                activity.getString(R.string.mt_domain_name_present_simple_tense)
+                activity.getString(R.string.mt_domain_name_present_simple_tense).replaceFirstChar { it.lowercase() }
 
             specificUrlParamsPstString =
-                activity.getString(R.string.mt_url_params_specific_present_simple_tense)
+                activity.getString(R.string.mt_url_params_specific_present_simple_tense).replaceFirstChar { it.lowercase() }
 
             cancelString = activity.getString(android.R.string.cancel)
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -2,26 +2,61 @@ package com.suvanl.fixmylinks.ui.components.list
 
 import android.content.res.Configuration
 import android.view.SoundEffectConstants
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.EaseOutQuint
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selectableGroup
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
 import com.suvanl.fixmylinks.ui.screens.RulesScreenUiState
+import com.suvanl.fixmylinks.ui.theme.active_status
 import com.suvanl.fixmylinks.ui.util.PreviewContainer
 import com.suvanl.fixmylinks.ui.util.PreviewData
+import kotlinx.coroutines.delay
+
+enum class RulesListCategory { ACTIVE, INACTIVE }
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -46,33 +81,119 @@ fun RulesList(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier.semantics { selectableGroup() }
     ) {
-        items(items = items) { rule ->
+        val activeRules = items.filter { it.isEnabled }
+        val inactiveRules = items.filter { !it.isEnabled }
+        val isInSelectionMode = selectedItems.isNotEmpty()
+
+        @Composable
+        fun Modifier.clickableItem(rule: BaseMutationModel): Modifier {
             val view = LocalView.current
             val haptics = LocalHapticFeedback.current
-            val isInSelectionMode = selectedItems.isNotEmpty()
 
-            RulesListItem(
-                rule = rule,
-                isSelected = selectedItems.contains(rule),
-                modifier = Modifier
-                    .combinedClickable(
-                        onClick = {
-                            if (isInSelectionMode) toggleItemSelection(rule) else onClickItem(rule)
-                            // Play click sound
-                            view.playSoundEffect(SoundEffectConstants.CLICK)
-                        },
-                        onLongClick = {
-                            toggleItemSelection(rule)
-                            // Perform long-press haptic feedback
-                            haptics.performHapticFeedback(HapticFeedbackType.LongPress)
-                        }
-                    )
+            return combinedClickable(
+                onClick = {
+                    if (isInSelectionMode) toggleItemSelection(rule) else onClickItem(rule)
+                    // Play click sound
+                    view.playSoundEffect(SoundEffectConstants.CLICK)
+                },
+                onLongClick = {
+                    toggleItemSelection(rule)
+                    // Perform long-press haptic feedback
+                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                }
             )
+        }
+
+        if (activeRules.isNotEmpty()) {
+            item { CategoryHeading(category = RulesListCategory.ACTIVE) }
+            items(items = activeRules) { rule ->
+                RulesListItem(
+                    rule = rule,
+                    isSelected = selectedItems.contains(rule),
+                    modifier = Modifier.clickableItem(rule)
+                )
+            }
+        }
+
+        if (inactiveRules.isNotEmpty()) {
+            item { CategoryHeading(category = RulesListCategory.INACTIVE) }
+            items(items = inactiveRules) { rule ->
+                RulesListItem(
+                    rule = rule,
+                    isSelected = selectedItems.contains(rule),
+                    modifier = Modifier.clickableItem(rule)
+                )
+            }
         }
 
         item {
             Spacer(modifier = Modifier.height(8.dp))
         }
+    }
+}
+
+@Composable
+private fun CategoryHeading(
+    category: RulesListCategory,
+    modifier: Modifier = Modifier
+) {
+    val isActive = category == RulesListCategory.ACTIVE
+
+    var showStatusCircle by remember { mutableStateOf(true) }
+    val rowSpacing by animateDpAsState(
+        targetValue = if (showStatusCircle) 8.dp else 0.dp,
+        animationSpec = tween(easing = EaseOutQuint),
+        label = "row arrangement spacedBy value"
+    )
+
+    val infiniteTransition = rememberInfiniteTransition(label = "repeating color animation")
+    val activeCircleAlpha by infiniteTransition.animateFloat(
+        initialValue = 1.0f,
+        targetValue = 0.2f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 700,
+                delayMillis = 200,
+                easing = EaseInOut
+            ),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "CategoryHeading active circle alpha"
+    )
+    val activeCircleColor = active_status.copy(alpha = activeCircleAlpha)
+    val inactiveCircleColor = MaterialTheme.colorScheme.outline
+
+    LaunchedEffect(key1 = Unit) {
+        delay(7000)
+        showStatusCircle = false
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(rowSpacing),
+        modifier = modifier
+            .fillMaxWidth()
+            .animateContentSize()
+    ) {
+        AnimatedVisibility(
+            visible = showStatusCircle,
+            enter = fadeIn()
+                    + slideInHorizontally(initialOffsetX = { w -> -w * 2 })
+                    + expandHorizontally(expandFrom = Alignment.Start, clip = false),
+            exit = fadeOut()
+                    + slideOutHorizontally(targetOffsetX = { w -> -w * 2 })
+                    + shrinkHorizontally(shrinkTowards = Alignment.Start, clip = false),
+        ) {
+            Canvas(modifier = Modifier.size(8.dp)) {
+                drawCircle(color = if (isActive) activeCircleColor else inactiveCircleColor)
+            }
+        }
+
+        Text(
+            text = stringResource(if (isActive) R.string.active_rules else R.string.inactive_rules),
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold
+        )
     }
 }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -146,7 +146,7 @@ private fun CategoryHeading(
         label = "row arrangement spacedBy value"
     )
 
-    val infiniteTransition = rememberInfiniteTransition(label = "repeating color animation")
+    val infiniteTransition = rememberInfiniteTransition(label = "CategoryHeading infiniteTransition")
     val activeCircleAlpha by infiniteTransition.animateFloat(
         initialValue = 1.0f,
         targetValue = 0.2f,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesListItem.kt
@@ -1,5 +1,6 @@
 package com.suvanl.fixmylinks.ui.components.list
 
+import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
@@ -59,7 +60,12 @@ fun RulesListItem(
     val (polygon, polygonSemantics) = getRoundedPolygonForRule(rule.mutationType)
     val rulePst = getRuleTypeInPresentSimpleTense(ruleType = rule.mutationType)
     val parentContentDescription =
-        stringResource(R.string.cd_rules_list_item, rule.name, rule.triggerDomain, rulePst.asString())
+        stringResource(
+            R.string.cd_rules_list_item,
+            rule.name,
+            rule.triggerDomain,
+            rulePst.asString()
+        )
 
     val shapeMorphProgress = remember { Animatable(0f) }
     val morphed by remember {
@@ -158,7 +164,16 @@ private suspend fun doAnimation(
     )
 }
 
-@Preview(widthDp = 380, showBackground = true)
+@Preview(
+    widthDp = 380,
+    showBackground = true
+)
+@Preview(
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    widthDp = 380,
+    showBackground = true
+)
 @Composable
 private fun ItemPreview() {
     PreviewContainer {
@@ -170,7 +185,16 @@ private fun ItemPreview() {
     }
 }
 
-@Preview(widthDp = 380, showBackground = true)
+@Preview(
+    widthDp = 380,
+    showBackground = true
+)
+@Preview(
+    name = "Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    widthDp = 380,
+    showBackground = true
+)
 @Composable
 private fun ItemSelectedPreview() {
     PreviewContainer {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/navigation/FmlNavHost.kt
@@ -223,6 +223,15 @@ fun FmlNavHost(
                                 inclusive = false
                             )
                         }
+                    },
+                    onEnabledStateChanged = { isEnabled ->
+                        if (selectedRule == null) {
+                            throw IllegalStateException("Shouldn't be able to change the isEnabled property of a null rule (BaseMutationModel)")
+                        }
+
+                        coroutineScope.launch {
+                            viewModel.toggleRuleEnabled(selectedRule!!, isEnabled)
+                        }
                     }
                 )
             }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -105,7 +105,7 @@ fun RuleDetailsScreen(
 
         RuleTypeDescription(rule = rule)
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         RuleEnabledSwitch(
             checked = rule.isEnabled,
@@ -159,12 +159,7 @@ private fun RuleTypeDescription(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         modifier = modifier
             .fillMaxWidth()
-//            .background(
-//                color = MaterialTheme.colorScheme.secondaryContainer,
-//                shape = RoundedCornerShape(50.dp)
-//            )
             .padding(
-                horizontal = 20.dp,
                 vertical = 20.dp
             )
     ) {
@@ -187,8 +182,14 @@ private fun RuleTypeDescription(
                 Text(text = "This rule", style = MaterialTheme.typography.bodyMedium)
             }
 
+            val descriptionText = if (lineCount < 2) {
+                ruleTypeInfo.replaceFirstChar { it.lowercase() }
+            } else {
+                ruleTypeInfo
+            }
+
             Text(
-                text = ruleTypeInfo,
+                text = descriptionText,
                 maxLines = 2,
                 letterSpacing = when (ruleTypeInfo.length) {
                     in 20..29 -> LetterSpacingDefaults.Tight

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -134,6 +134,7 @@ private fun RuleEnabledSwitch(
                 shape = RoundedCornerShape(28.dp)
             )
             .padding(horizontal = 20.dp, vertical = 16.dp)
+            .semantics { testTag = "RuleEnabledSwitch" }
     ) {
         Text(
             text = stringResource(R.string.rule_enabled_switch_title),

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -142,6 +142,7 @@ private fun RuleEnabledSwitch(
             fontSize = 20.sp,
             fontWeight = FontWeight.Medium,
             letterSpacing = LetterSpacingDefaults.ExtraTight,
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
             modifier = Modifier.weight(1F)
         )
         Switch(checked, onCheckedChange)

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -73,6 +74,7 @@ import com.suvanl.fixmylinks.ui.util.getShapeForRule
  * @param showDeleteConfirmation Whether to display the "Delete rule" [AlertDialog].
  * @param onDismissDeleteConfirmation When the "Delete rule" [AlertDialog] is dismissed.
  * @param onDelete When the user clicks the `confirmButton` on the "Delete rule" dialog.
+ * @param onEnabledStateChanged Called when the [RuleEnabledSwitch]'s checked state is changed.
  * @param modifier The default modifier for this screen.
  */
 @Composable
@@ -81,6 +83,7 @@ fun RuleDetailsScreen(
     showDeleteConfirmation: Boolean,
     onDismissDeleteConfirmation: () -> Unit,
     onDelete: () -> Unit,
+    onEnabledStateChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (rule == null) return
@@ -100,58 +103,100 @@ fun RuleDetailsScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Rule type description
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    color = MaterialTheme.colorScheme.secondaryContainer,
-                    shape = RoundedCornerShape(50.dp)
-                )
-                .padding(
-                    horizontal = 20.dp,
-                    vertical = 20.dp
-                )
-        ) {
-            Box(
-                modifier = Modifier
-                    .size(50.dp)
-                    .background(
-                        color = MaterialTheme.colorScheme.onSecondaryContainer,
-                        shape = getShapeForRule(rule.mutationType).shape
-                    )
-            )
+        RuleTypeDescription(rule = rule)
 
-            Column(
-                modifier = Modifier.weight(1F)
-            ) {
-                val ruleTypeInfo = getRuleTypeInPresentSimpleTense(rule.mutationType).asString()
-                var lineCount by remember { mutableIntStateOf(0) }
+        Spacer(modifier = Modifier.height(32.dp))
 
-                if (lineCount < 2) {
-                    Text(text = "This rule", style = MaterialTheme.typography.bodyMedium)
-                }
-
-                Text(
-                    text = ruleTypeInfo,
-                    maxLines = 2,
-                    letterSpacing = when (ruleTypeInfo.length) {
-                        in 20..29 -> LetterSpacingDefaults.Tight
-                        in 30..39 -> LetterSpacingDefaults.Tighter
-                        in 40..Int.MAX_VALUE -> LetterSpacingDefaults.ExtraTight
-                        else -> 0.sp
-                    },
-                    onTextLayout = { lineCount = it.lineCount }
-                )
-            }
-        }
+        RuleEnabledSwitch(
+            checked = rule.isEnabled,
+            onCheckedChange = onEnabledStateChanged,
+            modifier = Modifier.fillMaxWidth()
+        )
 
         Spacer(modifier = Modifier.height(32.dp))
 
         // General details
         RuleDetailsExpandingCard(rule = rule)
+    }
+}
+
+@Composable
+private fun RuleEnabledSwitch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .background(
+                color = MaterialTheme.colorScheme.primaryContainer,
+                shape = RoundedCornerShape(28.dp)
+            )
+            .padding(horizontal = 20.dp, vertical = 16.dp)
+    ) {
+        Text(
+            text = "Apply this rule",
+            style = MaterialTheme.typography.titleLarge,
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Medium,
+            letterSpacing = LetterSpacingDefaults.ExtraTight,
+            modifier = Modifier.weight(1F)
+        )
+        Switch(checked, onCheckedChange)
+    }
+}
+
+@Composable
+private fun RuleTypeDescription(
+    rule: BaseMutationModel,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier
+            .fillMaxWidth()
+//            .background(
+//                color = MaterialTheme.colorScheme.secondaryContainer,
+//                shape = RoundedCornerShape(50.dp)
+//            )
+            .padding(
+                horizontal = 20.dp,
+                vertical = 20.dp
+            )
+    ) {
+        Box(
+            modifier = Modifier
+                .size(50.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    shape = getShapeForRule(rule.mutationType).shape
+                )
+        )
+
+        Column(
+            modifier = Modifier.weight(1F)
+        ) {
+            val ruleTypeInfo = getRuleTypeInPresentSimpleTense(rule.mutationType).asString()
+            var lineCount by remember { mutableIntStateOf(0) }
+
+            if (lineCount < 2) {
+                Text(text = "This rule", style = MaterialTheme.typography.bodyMedium)
+            }
+
+            Text(
+                text = ruleTypeInfo,
+                maxLines = 2,
+                letterSpacing = when (ruleTypeInfo.length) {
+                    in 20..29 -> LetterSpacingDefaults.Tight
+                    in 30..39 -> LetterSpacingDefaults.Tighter
+                    in 40..Int.MAX_VALUE -> LetterSpacingDefaults.ExtraTight
+                    else -> 0.sp
+                },
+                onTextLayout = { lineCount = it.lineCount }
+            )
+        }
     }
 }
 
@@ -353,6 +398,7 @@ private fun RuleDetailsScreenPreview() {
             showDeleteConfirmation = false,
             onDismissDeleteConfirmation = { },
             onDelete = { },
+            onEnabledStateChanged = {},
         )
     }
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -136,7 +136,7 @@ private fun RuleEnabledSwitch(
             .padding(horizontal = 20.dp, vertical = 16.dp)
     ) {
         Text(
-            text = "Apply this rule",
+            text = stringResource(R.string.rule_enabled_switch_title),
             style = MaterialTheme.typography.titleLarge,
             fontSize = 20.sp,
             fontWeight = FontWeight.Medium,

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Color.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/theme/Color.kt
@@ -66,3 +66,6 @@ val md_theme_dark_scrim = Color(0xFF000000)
 
 
 val seed = Color(0xFF255FA4)
+
+// Custom colors (not part of Material theme)
+val active_status = Color(0xFF3DDC84)

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/PreviewData.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/PreviewData.kt
@@ -31,5 +31,15 @@ object PreviewData {
                 removableParams = listOf("list", "t")
             )
         ),
+        SpecificUrlParamsMutationModel(
+            name = "YouTube - remove timestamp",
+            triggerDomain = "youtube.com",
+            isLocalOnly = true,
+            isEnabled = false,
+            dateModifiedTimestamp = 1701970464,
+            mutationInfo = SpecificUrlParamsMutationInfo(
+                removableParams = listOf("t")
+            )
+        ),
     )
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/RulesViewModel.kt
@@ -3,7 +3,12 @@ package com.suvanl.fixmylinks.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.suvanl.fixmylinks.data.repository.RulesRepository
+import com.suvanl.fixmylinks.domain.mutation.model.AllUrlParamsMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndAllUrlParamsMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameAndSpecificUrlParamsMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationModel
+import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationModel
 import com.suvanl.fixmylinks.ui.screens.RulesScreenUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -61,6 +66,19 @@ class RulesViewModel @Inject constructor(
 
     suspend fun deleteAllRules() {
         rulesRepository.deleteAllRules()
+    }
+
+    suspend fun toggleRuleEnabled(rule: BaseMutationModel, isEnabled: Boolean) {
+        val updated = when (rule) {
+            is AllUrlParamsMutationModel -> rule.copy(isEnabled = isEnabled)
+            is DomainNameAndAllUrlParamsMutationModel -> rule.copy(isEnabled = isEnabled)
+            is DomainNameAndSpecificUrlParamsMutationModel -> rule.copy(isEnabled = isEnabled)
+            is DomainNameMutationModel -> rule.copy(isEnabled = isEnabled)
+            is SpecificUrlParamsMutationModel -> rule.copy(isEnabled = isEnabled)
+            else -> throw IllegalArgumentException("rule has unexpected type")
+        }
+
+        rulesRepository.updateRule(rule.baseRuleId, updated)
     }
 
     companion object {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,5 @@
     <string name="cd_add_wildcard_operator">Add wildcard operator</string>
     <string name="active_rules">Active rules</string>
     <string name="inactive_rules">Inactive rules</string>
+    <string name="rule_enabled_switch_title">Apply this rule</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,4 +84,6 @@
     <string name="cd_rules_list_item">%1$s on %2$s. %3$s.</string>
 
     <string name="cd_add_wildcard_operator">Add wildcard operator</string>
+    <string name="active_rules">Active rules</string>
+    <string name="inactive_rules">Inactive rules</string>
 </resources>


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

Closes #63



## 🧑‍💻 Implementation/changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
### RulesScreen
- Separate rules under two different headings/categories: "active rules" (enabled) and "inactive rules" (not enabled).
  - Each heading (CategoryHeading) within the RulesList has a coloured dot next to it.
    - Active rules have a green dot that blinks slowly.
    - Inactive rules have an "outline" coloured dot.
      - Comes from the Material theme colour palette and is typically a shade of grey.
  - The dot is a secondary detail (the text is the primary detail) since colour should never be used on its own to convey information, due to accessibility reasons such as the needs of colourblind users, etc. Therefore, this dot is hidden (animates out) after a set period of time (currently 7 seconds).

### RuleDetailsScreen
- Display a switch alongside "Apply this rule" text to indicate whether the rule is currently enabled or not.
- This switch can be toggled to modify the rule's `isEnabled` property without having to go into 'edit mode' (on AddRuleScreen) and toggle it from there.


## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
- (RuleDetailsScreenTest): Added tests to verify that the switch within the RuleEnabledSwitch composable is displayed with the correct checked state based on the value of the rule's `isEnabled` field.


## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A