### PR TITLE
✨ Display built-in rules in UI with active/inactive indication

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
 }
 
 dependencies {
-    val lifecycleVersion = "2.6.2"
-    val navVersion = "2.7.6"
+    val lifecycleVersion = "2.7.0"
+    val navVersion = "2.7.7"
     val roomVersion = "2.6.1"
     val daggerHiltVersion = "2.48.1"
     val androidxHiltVersion = "1.1.0"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,7 +86,7 @@ dependencies {
 
     implementation("androidx.datastore:datastore-preferences:$preferencesDataStoreVersion")
 
-    implementation(platform("androidx.compose:compose-bom:2023.10.01"))
+    implementation(platform("androidx.compose:compose-bom:2024.02.02"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -109,7 +109,7 @@ dependencies {
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0") // v5 drops Java 8 support
     testImplementation("androidx.room:room-testing:$roomVersion")
 
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.02"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     androidTestImplementation("androidx.test:runner:1.5.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     val navVersion = "2.7.7"
     val roomVersion = "2.6.1"
     val daggerHiltVersion = "2.48.1"
-    val androidxHiltVersion = "1.1.0"
+    val androidxHiltVersion = "1.2.0"
     val preferencesDataStoreVersion = "1.0.0"
 
     implementation("androidx.core:core-ktx:1.12.0")

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/components/list/CategoryHeadingTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/components/list/CategoryHeadingTest.kt
@@ -1,0 +1,38 @@
+package com.suvanl.fixmylinks.ui.components.list
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import org.junit.Rule
+import org.junit.Test
+
+class CategoryHeadingTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun categoryHeading_indicatorDot_isInitiallyShown_thenAnimatesOut() {
+        val indicatorTestTag = "indicator dot"
+        composeTestRule.setContent {
+            CategoryHeading(category = RulesListCategory.ACTIVE)
+        }
+
+        // Pause animations
+        composeTestRule.mainClock.autoAdvance = false
+
+        // Assert that the indicator dot is displayed
+        composeTestRule
+            .onNodeWithTag(indicatorTestTag)
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Let the animation proceed (allow additional 0.5 sec for it to animate out)
+        composeTestRule.mainClock.advanceTimeBy(INDICATOR_DOT_DISPLAY_DURATION + 500)
+
+        // Assert that the indicator is no longer displayed (as it has animated out)
+        composeTestRule
+            .onNodeWithTag(indicatorTestTag)
+            .assertDoesNotExist()
+    }
+}

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -46,12 +46,13 @@ class RulesScreenTest {
     }
 
     @Test
-    fun rulesScreen_withTwoSavedRules_displaysRulesListItem_forEachOne() {
+    fun rulesScreen_customRules_withTwoSavedRules_displaysRulesListItem_forEachOne() {
         val rules = fakeRules.take(2)
 
         composeTestRule.setContent {
-            RulesScreen(
+            CustomRulesBody(
                 uiState = RulesScreenUiState(rules = rules),
+                hasRules = rules.isNotEmpty(),
                 onClickRuleItem = {},
                 selectedItems = setOf(),
                 onUpdateSelectedItems = {},
@@ -74,12 +75,13 @@ class RulesScreenTest {
     }
 
     @Test
-    fun rulesScreen_itemsAreSelectable_and_singleSelectedRule_isSelected() {
+    fun rulesScreen_customRules_itemsAreSelectable_and_singleSelectedRule_isSelected() {
         val selectedRule = fakeRules[2]
 
         composeTestRule.setContent {
-            RulesScreen(
+            CustomRulesBody(
                 uiState = RulesScreenUiState(rules = fakeRules),
+                hasRules = fakeRules.isNotEmpty(),
                 onClickRuleItem = {},
                 selectedItems = setOf(selectedRule),
                 onUpdateSelectedItems = {},
@@ -106,10 +108,11 @@ class RulesScreenTest {
     }
 
     @Test
-    fun rulesScreen_shapeRepresentingRuleType_isDisplayed() {
+    fun rulesScreen_customRules_shapeRepresentingRuleType_isDisplayed() {
         composeTestRule.setContent {
-            RulesScreen(
+            CustomRulesBody(
                 uiState = RulesScreenUiState(rules = fakeRules),
+                hasRules = fakeRules.isNotEmpty(),
                 onClickRuleItem = {},
                 selectedItems = setOf(),
                 onUpdateSelectedItems = {},
@@ -127,10 +130,11 @@ class RulesScreenTest {
     }
 
     @Test
-    fun rulesScreen_correctShapeForEachRuleType_isDisplayed() {
+    fun rulesScreen_customRules_correctShapeForEachRuleType_isDisplayed() {
         composeTestRule.setContent {
-            RulesScreen(
+            CustomRulesBody(
                 uiState = RulesScreenUiState(rules = fakeRules),
+                hasRules = fakeRules.isNotEmpty(),
                 onClickRuleItem = {},
                 selectedItems = setOf(),
                 onUpdateSelectedItems = {},

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.MutationType
@@ -19,6 +20,7 @@ import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationInfo
 import com.suvanl.fixmylinks.domain.mutation.model.DomainNameMutationModel
 import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationInfo
 import com.suvanl.fixmylinks.domain.mutation.model.SpecificUrlParamsMutationModel
+import com.suvanl.fixmylinks.domain.mutation.rule.BuiltInRules
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -31,10 +33,12 @@ class RulesScreenTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private lateinit var noRulesAddedYetString: String
+    private lateinit var builtInTabLabel: String
 
     @Before
     fun setup() {
         noRulesAddedYetString = composeTestRule.activity.getString(R.string.no_rules_added_yet)
+        builtInTabLabel = composeTestRule.activity.getString(R.string.built_in)
     }
 
     @Test
@@ -179,6 +183,22 @@ class RulesScreenTest {
                         .assertIsDisplayed()
                 }
             }
+        }
+    }
+
+    @Test
+    fun rulesScreen_builtInRules_allRulesAreDisplayed() {
+        composeTestRule.setContent { EmptyRulesScreen() }
+
+        composeTestRule
+            .onNodeWithText(builtInTabLabel)
+            .performClick()
+
+        BuiltInRules.all.forEach {
+            composeTestRule
+                .onNodeWithText(it.name, useUnmergedTree = true)
+                .assertExists()
+                .assertIsDisplayed()
         }
     }
 

--- a/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
+++ b/app/src/androidTest/java/com/suvanl/fixmylinks/ui/screens/RulesScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelectable
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -200,6 +201,26 @@ class RulesScreenTest {
                 .assertExists()
                 .assertIsDisplayed()
         }
+    }
+
+    @Test
+    fun rulesScreen_selectedTabState_isPersistedAcrossActivityRecreation() {
+        val stateRestorationTester = StateRestorationTester(composeTestRule)
+        stateRestorationTester.setContent { EmptyRulesScreen() }
+
+        // Switch to "Built-in" tab
+        composeTestRule
+            .onNodeWithText(builtInTabLabel)
+            .performClick()
+            .assertIsSelected()
+
+        // Trigger recreation and state restoration
+        stateRestorationTester.emulateSavedInstanceStateRestore()
+
+        // Assert that the "Built-in" tab is still selected
+        composeTestRule
+            .onNodeWithText(builtInTabLabel)
+            .assertIsSelected()
     }
 
     companion object {

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/ReplaceDomainNameUseCase.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/ReplaceDomainNameUseCase.kt
@@ -18,6 +18,7 @@ class ReplaceDomainNameUseCase {
             val onlyTargetHasWildcardSubdomain =
                 mutationInfo.targetDomain.startsWith("*.") && !hasWildcardSubdomain
 
+            // TODO: clean up nested control flow; improve readability
             val domain = if (hasWildcardSubdomain) {
                 val subdomain = findSubdomain()
                 if (!subdomain.isNullOrBlank() && mutationInfo.targetDomain.startsWith("*.")) {

--- a/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/rule/BuiltInRules.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/domain/mutation/rule/BuiltInRules.kt
@@ -18,7 +18,8 @@ object BuiltInRules {
                 "_branch_match_id",
                 "_branch_referrer"
             )
-        )
+        ),
+        baseRuleId = -1,
     )
 
     private val InstagramTrackingParamsRule = SpecificUrlParamsMutationModel(
@@ -26,7 +27,8 @@ object BuiltInRules {
         triggerDomain = "instagram.com",
         isLocalOnly = true,
         isEnabled = true,
-        mutationInfo = SpecificUrlParamsMutationInfo(removableParams = listOf("igshid"))
+        mutationInfo = SpecificUrlParamsMutationInfo(removableParams = listOf("igshid")),
+        baseRuleId = -2,
     )
 
     private val XtoTwitterRule = DomainNameAndAllUrlParamsMutationModel(
@@ -34,7 +36,8 @@ object BuiltInRules {
         triggerDomain = "x.com",
         isLocalOnly = true,
         isEnabled = true,
-        mutationInfo = DomainNameMutationInfo(initialDomain = "x.com", targetDomain = "twitter.com")
+        mutationInfo = DomainNameMutationInfo(initialDomain = "x.com", targetDomain = "twitter.com"),
+        baseRuleId = -3,
     )
 
     val all = listOf(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -73,9 +73,10 @@ fun RulesList(
     fun toggleItemSelection(rule: BaseMutationModel) {
         if (selectedItems.contains(rule)) {
             onUpdateSelectedItems(selectedItems - rule)
-        } else {
-            onUpdateSelectedItems(selectedItems + rule)
+            return
         }
+
+        onUpdateSelectedItems(selectedItems + rule)
     }
 
     LazyColumn(

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -199,7 +199,7 @@ fun CategoryHeading(
 
         Text(
             text = stringResource(if (isActive) R.string.active_rules else R.string.inactive_rules),
-            color = MaterialTheme.colorScheme.primary,
+            color = MaterialTheme.colorScheme.secondary,
             fontWeight = FontWeight.SemiBold
         )
     }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.selectableGroup
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -132,8 +133,10 @@ fun RulesList(
     }
 }
 
+const val INDICATOR_DOT_DISPLAY_DURATION = 7000L
+
 @Composable
-private fun CategoryHeading(
+fun CategoryHeading(
     category: RulesListCategory,
     modifier: Modifier = Modifier
 ) {
@@ -146,7 +149,8 @@ private fun CategoryHeading(
         label = "row arrangement spacedBy value"
     )
 
-    val infiniteTransition = rememberInfiniteTransition(label = "CategoryHeading infiniteTransition")
+    val infiniteTransition =
+        rememberInfiniteTransition(label = "CategoryHeading infiniteTransition")
     val activeCircleAlpha by infiniteTransition.animateFloat(
         initialValue = 1.0f,
         targetValue = 0.2f,
@@ -164,7 +168,7 @@ private fun CategoryHeading(
     val inactiveCircleColor = MaterialTheme.colorScheme.outline
 
     LaunchedEffect(key1 = Unit) {
-        delay(7000)
+        delay(INDICATOR_DOT_DISPLAY_DURATION)
         showStatusCircle = false
     }
 
@@ -184,7 +188,11 @@ private fun CategoryHeading(
                     + slideOutHorizontally(targetOffsetX = { w -> -w * 2 })
                     + shrinkHorizontally(shrinkTowards = Alignment.Start, clip = false),
         ) {
-            Canvas(modifier = Modifier.size(8.dp)) {
+            Canvas(
+                modifier = Modifier
+                    .size(8.dp)
+                    .semantics { testTag = "indicator dot" }
+            ) {
                 drawCircle(color = if (isActive) activeCircleColor else inactiveCircleColor)
             }
         }

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/list/RulesList.kt
@@ -35,7 +35,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -142,7 +142,7 @@ fun CategoryHeading(
 ) {
     val isActive = category == RulesListCategory.ACTIVE
 
-    var showStatusCircle by remember { mutableStateOf(true) }
+    var showStatusCircle by rememberSaveable { mutableStateOf(true) }
     val rowSpacing by animateDpAsState(
         targetValue = if (showStatusCircle) 8.dp else 0.dp,
         animationSpec = tween(easing = EaseOutQuint),

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/FixMyLinksApp.kt
@@ -104,7 +104,14 @@ fun FixMyLinksApp(windowSize: WindowSizeClass) {
 
     val shouldShowTopAppBar = showNavBarOn.none { it.route == currentBaseRoute }
     val shouldShowAddNewRuleFab = topLevelScreensWithFab.any { it.route == currentBaseRoute }
-    val shouldShowEditRuleFab = currentBaseRoute.startsWith(FmlScreen.RuleDetails.route)
+
+    val detailsBaseRuleIdArg =
+        navBackStackEntry?.arguments?.getLong(FmlScreen.RuleDetails.baseRuleIdArg)
+
+    // Built-in rules have negative `baseRuleId`s, so only show the "edit" FAB if the ID is not negative
+    // (or zero, since no rule should have a baseRuleId of 0).
+    val shouldShowEditRuleFab =
+        currentBaseRoute.startsWith(FmlScreen.RuleDetails.route) && (detailsBaseRuleIdArg != null && detailsBaseRuleIdArg > 0)
 
     val shouldShowRulesMultiSelectTopAppBar =
         currentBaseRoute == FmlScreen.Rules.route && multiSelectedRules.isNotEmpty()

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
@@ -118,7 +118,7 @@ fun RulesScreen(
                 }
 
                 1 -> {
-                    BuiltInRulesBody()
+                    BuiltInRulesBody(onClickRuleItem = onClickRuleItem)
                 }
             }
         }
@@ -126,7 +126,10 @@ fun RulesScreen(
 }
 
 @Composable
-private fun BuiltInRulesBody(modifier: Modifier = Modifier) {
+private fun BuiltInRulesBody(
+    onClickRuleItem: (BaseMutationModel) -> Unit,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -134,7 +137,7 @@ private fun BuiltInRulesBody(modifier: Modifier = Modifier) {
     ) {
         RulesList(
             uiState = RulesScreenUiState(rules = BuiltInRules.all),
-            onClickItem = {},
+            onClickItem = onClickRuleItem,
             selectedItems = setOf(),
             onUpdateSelectedItems = {}
         )

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,7 +72,7 @@ fun RulesScreen(
     Column(
         modifier = modifier.semantics { contentDescription = "Rules Screen" }
     ) {
-        var selectedTabIndex by remember { mutableIntStateOf(0) }
+        var selectedTabIndex by rememberSaveable { mutableIntStateOf(0) }
         val pagerState = rememberPagerState { tabItems.size }
 
         LaunchedEffect(selectedTabIndex) {

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
@@ -1,21 +1,32 @@
 package com.suvanl.fixmylinks.ui.screens
 
 import android.content.res.Configuration
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -37,6 +48,11 @@ data class RulesScreenUiState(
     val rules: List<BaseMutationModel> = listOf()
 )
 
+data class TabItem(
+    val title: String
+)
+
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RulesScreen(
     uiState: RulesScreenUiState,
@@ -45,15 +61,84 @@ fun RulesScreen(
     onUpdateSelectedItems: (Set<BaseMutationModel>) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val tabItems = listOf(
+        TabItem(title = stringResource(R.string.custom)),
+        TabItem(title = stringResource(R.string.built_in)),
+    )
+
     val hasRules = uiState.rules.isNotEmpty()
 
+    Column(
+        modifier = modifier.semantics { contentDescription = "Rules Screen" }
+    ) {
+        var selectedTabIndex by remember { mutableIntStateOf(0) }
+        val pagerState = rememberPagerState { tabItems.size }
+
+        LaunchedEffect(selectedTabIndex) {
+            pagerState.animateScrollToPage(selectedTabIndex)
+        }
+
+        LaunchedEffect(pagerState.currentPage, pagerState.isScrollInProgress) {
+            if (!pagerState.isScrollInProgress) {
+                selectedTabIndex = pagerState.currentPage
+            }
+        }
+
+        TabRow(selectedTabIndex = selectedTabIndex, modifier = Modifier.padding(vertical = 8.dp)) {
+            tabItems.forEachIndexed { index, item ->
+                Tab(
+                    selected = index == selectedTabIndex,
+                    onClick = { selectedTabIndex = index },
+                    text = {
+                        Text(
+                            text = item.title,
+                            letterSpacing = LetterSpacingDefaults.Tight
+                        )
+                    }
+                )
+            }
+        }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1F)
+        ) { tabIndex ->
+            when (tabIndex) {
+                0 -> {
+                    CustomRulesBody(
+                        uiState = uiState,
+                        hasRules = hasRules,
+                        onClickRuleItem = onClickRuleItem,
+                        selectedItems = selectedItems,
+                        onUpdateSelectedItems = onUpdateSelectedItems
+                    )
+                }
+
+                1 -> {
+                    Text(text = "Built-in rules")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CustomRulesBody(
+    uiState: RulesScreenUiState,
+    hasRules: Boolean,
+    onClickRuleItem: (BaseMutationModel) -> Unit,
+    selectedItems: Set<BaseMutationModel>,
+    onUpdateSelectedItems: (Set<BaseMutationModel>) -> Unit,
+    modifier: Modifier = Modifier
+) {
     Column(
         horizontalAlignment = if (hasRules) Alignment.Start else Alignment.CenterHorizontally,
         verticalArrangement = if (hasRules) Arrangement.Top else Arrangement.Center,
         modifier = modifier
             .fillMaxSize()
             .padding(horizontal = 16.dp)
-            .semantics { contentDescription = "Rules Screen" }
     ) {
         if (!hasRules) {
             EmptyRulesBody()

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/RulesScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.suvanl.fixmylinks.R
 import com.suvanl.fixmylinks.domain.mutation.model.BaseMutationModel
+import com.suvanl.fixmylinks.domain.mutation.rule.BuiltInRules
 import com.suvanl.fixmylinks.ui.components.list.RulesList
 import com.suvanl.fixmylinks.ui.graphics.CustomShapes.ScallopPolygon
 import com.suvanl.fixmylinks.ui.layout.Polygon
@@ -117,10 +118,26 @@ fun RulesScreen(
                 }
 
                 1 -> {
-                    Text(text = "Built-in rules")
+                    BuiltInRulesBody()
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun BuiltInRulesBody(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(start = 16.dp, end = 16.dp, top = 16.dp)
+    ) {
+        RulesList(
+            uiState = RulesScreenUiState(rules = BuiltInRules.all),
+            onClickItem = {},
+            selectedItems = setOf(),
+            onUpdateSelectedItems = {}
+        )
     }
 }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -108,8 +108,6 @@ fun RuleDetailsScreen(
         }
     }
 
-    val isCustomRule = rule.baseRuleId > 0
-
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -129,15 +127,15 @@ fun RuleDetailsScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        if (isCustomRule) {
-            RuleEnabledSwitch(
-                checked = rule.isEnabled,
-                onCheckedChange = onEnabledStateChanged,
-                modifier = Modifier.fillMaxWidth()
-            )
+        val isCustomRule = rule.baseRuleId > 0
+        RuleEnabledSwitch(
+            checked = rule.isEnabled,
+            onCheckedChange = onEnabledStateChanged,
+            isEnabled = isCustomRule,
+            modifier = Modifier.fillMaxWidth()
+        )
 
-            Spacer(modifier = Modifier.height(32.dp))
-        }
+        Spacer(modifier = Modifier.height(32.dp))
 
         // General details
         RuleDetailsExpandingCard(rule = rule)
@@ -148,7 +146,8 @@ fun RuleDetailsScreen(
 private fun RuleEnabledSwitch(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isEnabled: Boolean = true,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -169,7 +168,12 @@ private fun RuleEnabledSwitch(
             color = MaterialTheme.colorScheme.onPrimaryContainer,
             modifier = Modifier.weight(1F)
         )
-        Switch(checked, onCheckedChange)
+
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = isEnabled
+        )
     }
 }
 

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -108,6 +108,8 @@ fun RuleDetailsScreen(
         }
     }
 
+    val isCustomRule = rule.baseRuleId > 0
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -127,13 +129,15 @@ fun RuleDetailsScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        RuleEnabledSwitch(
-            checked = rule.isEnabled,
-            onCheckedChange = onEnabledStateChanged,
-            modifier = Modifier.fillMaxWidth()
-        )
+        if (isCustomRule) {
+            RuleEnabledSwitch(
+                checked = rule.isEnabled,
+                onCheckedChange = onEnabledStateChanged,
+                modifier = Modifier.fillMaxWidth()
+            )
 
-        Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(32.dp))
+        }
 
         // General details
         RuleDetailsExpandingCard(rule = rule)

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/screens/details/RuleDetailsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.outlined.ExpandMore
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Language
 import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -86,7 +87,26 @@ fun RuleDetailsScreen(
     onEnabledStateChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    if (rule == null) return
+    if (rule == null) {
+        return Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Warning,
+                    contentDescription = null,
+                    modifier = Modifier.size(64.dp)
+                )
+                Text(
+                    text = "No data found for this rule",
+                    style = MaterialTheme.typography.titleLarge
+                )
+            }
+        }
+    }
 
     Column(
         modifier = modifier

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/util/PreviewData.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/util/PreviewData.kt
@@ -19,7 +19,8 @@ object PreviewData {
             mutationInfo = DomainNameMutationInfo(
                 initialDomain = "google.com",
                 targetDomain = "google.co.uk"
-            )
+            ),
+            baseRuleId = 1
         ),
         SpecificUrlParamsMutationModel(
             name = "YouTube - remove playlist association and timestamp, but nothing else",
@@ -29,7 +30,8 @@ object PreviewData {
             dateModifiedTimestamp = 1701970463,
             mutationInfo = SpecificUrlParamsMutationInfo(
                 removableParams = listOf("list", "t")
-            )
+            ),
+            baseRuleId = 2
         ),
         SpecificUrlParamsMutationModel(
             name = "YouTube - remove timestamp",
@@ -39,7 +41,8 @@ object PreviewData {
             dateModifiedTimestamp = 1701970464,
             mutationInfo = SpecificUrlParamsMutationInfo(
                 removableParams = listOf("t")
-            )
+            ),
+            baseRuleId = 3
         ),
     )
 }

--- a/app/src/main/java/com/suvanl/fixmylinks/viewmodel/RulesViewModel.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/viewmodel/RulesViewModel.kt
@@ -50,6 +50,9 @@ class RulesViewModel @Inject constructor(
     suspend fun refreshSelectedRule() {
         if (_selectedRule.value == null) return
 
+        val isBuiltInRule = _selectedRule.value!!.baseRuleId < 0
+        if (isBuiltInRule) return
+
         rulesRepository.getRuleByBaseId(
             _selectedRule.value!!.baseRuleId,
             _selectedRule.value!!.mutationType

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,4 +87,6 @@
     <string name="active_rules">Active rules</string>
     <string name="inactive_rules">Inactive rules</string>
     <string name="rule_enabled_switch_title">Apply this rule</string>
+    <string name="custom">Custom</string>
+    <string name="built_in">Built-in</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.0" apply false
+    id("com.android.application") version "8.3.0" apply false
     id("org.jetbrains.kotlin.android") version "1.9.20" apply false
     id("com.guardsquare.appsweep") version "latest.release" apply false
     id("com.google.dagger.hilt.android") version "2.44" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Sep 13 17:03:15 BST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

Closes #64 



## 🧑‍💻 Implementation/changelog
<!-- How does this PR solve the problem? What technical approach and steps were taken to solve it? -->
- Add tabs ("Custom" and "Built-in") to RulesScreen. (8c8e0166560322c115c2875f3c4dad9bb7518089)
  - These tabs can be swiped between.
- Change CategoryHeading text colour to `secondary`, as the tabs use the `primary` Material theme colour. (1142e698dfc2419fc11a25f58f9e72931e8999ca)
- Display built-in rules under the "Built-in" tab. (2bc502f3ef0a4b441096a494b4991c5c43415540)
- Assign a negative `baseRuleId` to all built-in rules to differentiate them from custom rules (which have positive `baseRuleId`s). (16debe523b95f69c6f17f6ac088ce9359e0f51c4)
- Use same click behaviour from custom rule cards for built-in rule cards. (96f0c5da9df09a9f1dea5798a11ce2043d610b00)
  - Clicking on a card navigates to RuleDetailsScreen, where additional info about the rule is displayed.
- Display the RuleEnabledSwitch on RuleDetailsScreen for built-in rules (just like with custom rules), but disable the switch so that it cannot be toggled. (a13f3e1d1d02325657d0641de9c9b751435a8705)
  - Because it currently isn't possible to switch off built-in rules.

## 🧪 Testing
<!--
- How did you verify that this change works as desired? Were any automated tests added? Did you test these changes against existing automated tests?

- If new instrumentation tests were added, what device were they run on? (State whether the device is emulated or physical)

- What manual testing was performed?
-->
- Test CategoryHeading indicator animation to verify that the indicator dot disappears after the set amount of time (c4765ac19f3e96535d7f4c4466b7f70f7cee21a7)
- Modify RulesScreenTest to explicitly test CustomRulesBody (9b22f106098ee33387ec05cd9c669ef0aae0aeed)
- Verify that all built-in rules are displayed under the "Built-in" tab on RulesScreen (ad1ed06dd0136710a83c092e355c0c6356470530)
- (RulesScreenTest): Verify that selected tab state is persisted across activity/process recreation (f481c962bd690733821b3d6773a2c5f68f6d4642)

## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
No related or dependent open PRs, but #66 may require assigning positive `baseRuleId`s to built-in rules, if a new `is_built_in` or `is_custom` column is added to the rules table.