### PR TITLE
Fix NavigationBar padding bug and update outdated actions

### DIFF
--- a/.github/workflows/appsweep-scan.yml
+++ b/.github/workflows/appsweep-scan.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set outputs
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -92,10 +92,10 @@ jobs:
         api-level: [33, 34]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/detect-changes.yml
+++ b/.github/workflows/detect-changes.yml
@@ -29,10 +29,10 @@ jobs:
       test: ${{ steps.filter.outputs.test }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: github.event_name == 'push'
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: ${{ always() }}
         id: filter
         with:

--- a/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationBar.kt
+++ b/app/src/main/java/com/suvanl/fixmylinks/ui/components/nav/NavigationBar.kt
@@ -1,7 +1,5 @@
 package com.suvanl.fixmylinks.ui.components.nav
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -10,12 +8,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
 import com.suvanl.fixmylinks.ui.navigation.FmlScreen
 import com.suvanl.fixmylinks.ui.theme.LetterSpacingDefaults
+import com.suvanl.fixmylinks.ui.util.PreviewContainer
+import com.suvanl.fixmylinks.ui.util.topLevelScreens
 
 @Composable
 fun FmlNavigationBar(
@@ -43,21 +43,26 @@ fun FmlNavigationBar(
                     )
                 },
                 label = {
-                    Column {
-                        Text(
-                            text = stringResource(id = screen.label),
-                            letterSpacing = LetterSpacingDefaults.Tight,
-                            fontWeight = if (isSelected) {
-                                FontWeight.Bold
-                            } else {
-                                FontWeight.Normal
-                            },
-                            fontSize = 13.sp,
-                            modifier = Modifier.padding(top = 64.dp)
-                        )
-                    }
+                    Text(
+                        text = stringResource(id = screen.label),
+                        letterSpacing = LetterSpacingDefaults.Tight,
+                        fontWeight = if (isSelected) {
+                            FontWeight.Bold
+                        } else {
+                            FontWeight.Normal
+                        },
+                        fontSize = 13.sp,
+                    )
                 }
             )
         }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun NavigationBarPreview() {
+    PreviewContainer {
+        FmlNavigationBar(navItems = topLevelScreens, currentDestination = null, onNavItemClick = {})
     }
 }


### PR DESCRIPTION
[//]: # (Adapted from this example PR template: https://gist.github.com/braddotcoffee/f0304bedfe21d8e9ebd60bee7c3986ca)

[//]: # (DON'T delete any comments [text enclosed within `<!-- -->`]. Ensure you answer the questions these comments ask.)

## 💡 Motivation
<!-- Why is this change necessary? What problem does it solve? -->

- After updating the Compose BOM version (and thus the Compose Material 3 library), the padding in the navbar became excessive, therefore it has been removed to retain the same layout/design as before.

- The `checkout`, `setup-java`, and `paths-filter` actions use a deprecated Node.js version (16). We now use their latest versions which use Node 20.


## 🔗 Related/dependent PRs (optional)
<!--
Optional: do any other PRs provide additional context to this one? Does this PR's mergeability depend on any other PRs being merged first?
-->
N/A